### PR TITLE
Add kiarash-portfolio-mcp.json configuration file

### DIFF
--- a/packages/uncategorized/kiarash-portfolio-mcp.json
+++ b/packages/uncategorized/kiarash-portfolio-mcp.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "kiarash-portfolio-mcp",
+  "description": "WebMCP-enabled portfolio with Ed25519 signed discovery. AI agents can query projects, skills, and execute terminal commands via HTTP API.",
+  "url": "https://kiarash-adl.pages.dev/.well-known/mcp.llmfeed.json",
+  "runtime": "remote",
+  "license": "MIT",
+  "author": "Kiarash Adl",
+  "tags": ["portfolio", "webmcp", "cloudflare", "ed25519"],
+  "tools": [
+    {
+      "name": "get_project_details",
+      "description": "Get detailed info about portfolio projects"
+    },
+    {
+      "name": "run_terminal_command",
+      "description": "Execute terminal commands: about, skills, projects, contact"
+    }
+  ]
+}


### PR DESCRIPTION
Adds my portfolio's WebMCP server to the registry.

**Features:**
- Ed25519 signed discovery manifest
- 2 tools: `get_project_details`, `run_terminal_command`
- Runs on Cloudflare Pages edge network
- Standard WebMCP format at `/.well-known/mcp.llmfeed.json`

**Live endpoint:** https://kiarash-adl.pages.dev/.well-known/mcp.llmfeed.json