### PR TITLE
Add AgentsKB - researched knowledge base for AI assistants

### DIFF
--- a/packages/knowledge-memory/agentskb-mcp.json
+++ b/packages/knowledge-memory/agentskb-mcp.json
@@ -1,0 +1,9 @@
+{
+  "type": "mcp-server",
+  "name": "AgentsKB MCP",
+  "packageName": "@agentskb/cli",
+  "description": "Pre-researched knowledge base for AI coding assistants. Provides 5,700+ Q&As covering PostgreSQL, Next.js, Prisma, FastAPI, Docker, AWS, and 40+ other developer domains to ensure AI gets specific technical details right.",
+  "url": "https://github.com/Cranot/agentskb-mcp",
+  "runtime": "node",
+  "license": "unknown"
+}


### PR DESCRIPTION
Hey! I'd like to add AgentsKB to this list.

## What is it?

AgentsKB is a pre-researched knowledge base for AI coding assistants. We have 5,700+ Q&As covering PostgreSQL, Next.js, Prisma, FastAPI, Docker, AWS, and 40+ other developer domains.

The idea: LLMs are great at reasoning but often get specific technical details wrong (default values, exact limits, version-specific behavior). We research those answers upfront so your AI gets them right.

## MCP Tools

- `ask_question` - Get a researched answer with source citations
- `preflight_check` - See what knowledge exists before starting a task
- `search_questions` - Browse related Q&As on a topic

## Installation

```json
{
  "mcpServers": {
    "agentskb": {
      "command": "npx",
      "args": ["@agentskb/cli", "mcp"]
    }
  }
}
```

## Links

- Website: https://agentskb.com
- GitHub: https://github.com/Cranot/agentskb-mcp
- npm: https://www.npmjs.com/package/@agentskb/cli

Free tier: 300 queries/month, no API key needed.

Let me know if you'd like any changes to the entry!