### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/packages/other-tools-and-integrations/taskade-mcp.json
+++ b/packages/other-tools-and-integrations/taskade-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "packageName": "@taskade/mcp-server",
+  "description": "Official Taskade MCP server with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media.",
+  "url": "https://github.com/taskade/mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "TASKADE_API_KEY": {
+      "description": "API key for Taskade API access",
+      "required": true
+    }
+  },
+  "name": "Taskade MCP Server"
+}


### PR DESCRIPTION
## Add Taskade MCP Server

Adds [Taskade MCP Server](https://github.com/taskade/mcp) to the registry under `other-tools-and-integrations`.

**Taskade MCP Server** (`@taskade/mcp-server`) is the official MCP server for [Taskade](https://www.taskade.com/) with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. It works with Claude, Cursor, Windsurf, VS Code, and all MCP clients.

- GitHub: https://github.com/taskade/mcp
- npm: `@taskade/mcp-server`
- License: MIT
- Runtime: Node.js