### PR TITLE
Add BGPT MCP to search-data-extraction

### DIFF
--- a/packages/search-data-extraction/bgpt-mcp.json
+++ b/packages/search-data-extraction/bgpt-mcp.json
@@ -6,10 +6,5 @@
   "url": "https://github.com/connerlambden/bgpt-mcp",
   "runtime": "node",
   "license": "MIT",
-  "remotes": [
-    {
-      "type": "sse",
-      "url": "https://bgpt.pro/mcp/sse"
-    }
-  ]
+  "env": {}
 }


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — search scientific papers with structured experimental data from full-text studies. Returns 25+ fields per paper including methods, results, sample sizes, and quality scores.

Remote SSE endpoint: `https://bgpt.pro/mcp/sse`
Free tier: 50 searches, no API key needed.