### PR TITLE
feat: Add Taskade MCP server

### DIFF
--- a/packages/other-tools-and-integrations/taskade-mcp-server.json
+++ b/packages/other-tools-and-integrations/taskade-mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "Taskade",
+  "packageName": "@taskade/mcp-server",
+  "description": "Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, templates, and workflow automations. Includes OpenAPI-to-MCP codegen utility.",
+  "url": "https://github.com/taskade/mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "TASKADE_API_KEY": {
+      "description": "Taskade Personal Access Token from https://www.taskade.com/settings/api",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the official **Taskade MCP server** (`@taskade/mcp-server`) to the registry under `other-tools-and-integrations`
- Taskade provides 50+ MCP tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, templates, and workflow automations
- Package is available on npm: [@taskade/mcp-server](https://www.npmjs.com/package/@taskade/mcp-server)
- GitHub repo: https://github.com/taskade/mcp
- Website: https://taskade.com
- License: MIT

## Entry Details

| Field | Value |
|-------|-------|
| `type` | `mcp-server` |
| `name` | `Taskade` |
| `packageName` | `@taskade/mcp-server` |
| `runtime` | `node` |
| `license` | `MIT` |
| `env` | `TASKADE_API_KEY` (required) |

## Checklist

- [x] JSON file follows the registry schema (`MCPServerPackageConfigSchema`)
- [x] All required fields (`type`, `runtime`, `packageName`, `env`) are present
- [x] Package exists on npm
- [x] GitHub URL is valid and public
- [x] No sensitive data included