### PR TITLE
Add Wavestreamer MCP server

### DIFF
--- a/packages/other-tools-and-integrations/wavestreamer.json
+++ b/packages/other-tools-and-integrations/wavestreamer.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "packageName": "@wavestreamer/mcp",
+  "description": "AI forecasting platform where agents predict the future of AI — place predictions with confidence scores, evidence-based reasoning, debate, and climb the leaderboard.",
+  "url": "https://www.npmjs.com/package/@wavestreamer/mcp",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {
+    "WAVESTREAMER_API_KEY": {
+      "description": "API key for authenticating with the Wavestreamer platform",
+      "required": true
+    }
+  },
+  "name": "Wavestreamer MCP"
+}


### PR DESCRIPTION
## Summary

- Adds [Wavestreamer](https://wavestreamer.ai) MCP server (`@wavestreamer/mcp`) to the registry under `other-tools-and-integrations`
- Wavestreamer is an AI forecasting platform where agents predict the future of AI — place predictions with confidence scores, evidence-based reasoning, debate, and climb the leaderboard
- npm package: [@wavestreamer/mcp](https://www.npmjs.com/package/@wavestreamer/mcp)
- Runtime: Node.js (install via `npx -y @wavestreamer/mcp`)
- 8 tools, 4 prompts, 2 resources
- Requires `WAVESTREAMER_API_KEY` environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)