### PR TITLE
feat(mcp): add cocoindex-code MCP server

### DIFF
--- a/packages/uncategorized/cocoindex-code.json
+++ b/packages/uncategorized/cocoindex-code.json
@@ -1,9 +1,9 @@
 {
   "type": "mcp-server",
-  "name": "CocoIndex",
-  "packageName": "cocoindex",
+  "name": "cocoindex-code",
+  "packageName": "cocoindex-code",
   "description": "A super lightweight, effective embedded MCP that understands and searches your codebase that just works! Works for Claude, Codex, Cursor - any coding agent. Instant token saving by 70%.",
-  "url": "https://github.com/cocoindex-io/cocoindex",
+  "url": "https://github.com/cocoindex-io/cocoindex-code",
   "runtime": "python",
   "license": "Apache-2.0",
   "env": {}


### PR DESCRIPTION
## Add CocoIndex MCP Server

Adds [cocoindex-code](https://github.com/cocoindex-io/cocoindex-code) to the registry.

- **Package**: `cocoindex-code` (PyPI)
- **Runtime**: Python
- **License**: Apache-2.0
- **Description**: A super lightweight, effective embedded MCP that understands and searches your codebase. Works for Claude, Codex, Cursor - any coding agent. Instant token saving by 70%.