### PR TITLE
Add LightCMS MCP server

### DIFF
--- a/packages/developer-tools/lightcms.json
+++ b/packages/developer-tools/lightcms.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "LightCMS",
+  "packageName": "lightcms",
+  "description": "AI-native CMS with 41 MCP tools for managing websites through natural language.",
+  "url": "https://github.com/jonradoff/lightcms",
+  "runtime": "go",
+  "license": "MIT",
+  "env": {
+    "LIGHTCMS_URL": {
+      "description": "LightCMS server URL",
+      "required": true
+    },
+    "LIGHTCMS_API_KEY": {
+      "description": "API key for authenticating with the LightCMS server",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds LightCMS to the registry under `packages/developer-tools/lightcms.json`
- LightCMS is an AI-native CMS with 41 MCP tools for managing websites through natural language
- Runtime: Go, License: MIT
- Repo: https://github.com/jonradoff/lightcms

## Details
- **Transport**: stdio
- **Environment variables**: `LIGHTCMS_URL` (server URL), `LIGHTCMS_API_KEY` (API key)
- **Author**: Jon Radoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)