### PR TITLE
Add commune-mcp to registry

### DIFF
--- a/packages/communication/commune-mcp.json
+++ b/packages/communication/commune-mcp.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "../../schema.json",
   "type": "mcp-server",
   "name": "Commune MCP",
   "packageName": "commune-mcp",
@@ -12,10 +11,5 @@
       "description": "API key for Commune service",
       "required": true
     }
-  },
-  "tags": [
-    "email",
-    "communication",
-    "sms"
-  ]
+  }
 }


### PR DESCRIPTION
Adding commune-mcp to the registry, slotted alphabetically after coda-mcp.

It's email infrastructure built specifically for agents — not a wrapper around a user's Gmail, but a server you provision inboxes from programmatically. Agents can send and receive email, track threads across multiple concurrent conversations, use custom sending domains, and get inbound mail back as structured data rather than raw HTML.

Also supports SMS from the same server.

Install: uvx commune-mcp | API key auth | Python | https://github.com/commune-sh/commune-mcp