### PR TITLE
Add OpenDirectories Business Data MCP server

### DIFF
--- a/packages/data-platforms/toolsdk-remote-opendirectories-business-data.json
+++ b/packages/data-platforms/toolsdk-remote-opendirectories-business-data.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
   "name": "OpenDirectories Business Data",
-  "packageName": "opendirectories-mcp",
+  "packageName": "@toolsdk-remote/opendirectories-business-data",
   "description": "Search 12M+ verified businesses across 10 countries via government registers. Government-sourced, Google Maps enriched. 6 tools for search, verification, competitor analysis, and market research.",
   "url": "https://github.com/BigJai/opendirectories-mcp",
   "runtime": "python",
   "license": "MIT",
-  "env": {},
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## MCP Server Information

**Server Name:** OpenDirectories Business Data
**Package Name:** opendirectories-mcp (PyPI)
**Repository:** https://github.com/BigJai/opendirectories-mcp
**Runtime:** Python
**License:** MIT
**Category:** data-platforms

## Description

Search 12M+ verified businesses across 10 countries (AU, US, UK, CA, NZ, SG, IE, FR) via government registers. Data sourced from official government business registries and enriched with Google Maps data.

## Tools

| Tool | Description |
|------|-------------|
| `search_businesses` | Full-text search across all directories with filters |
| `get_business` | Complete business details by ID |
| `get_competitors` | Find competing businesses nearby |
| `market_density` | Analyze market saturation |
| `verify_business` | Cross-reference against government data |
| `list_directories` | List available directories |

## Remote Endpoint

No authentication required:
```
https://secure-wave--opendirectories-business-data.apify.actor/mcp
```

## Local Install

```bash
uvx opendirectories-mcp
```