### PR TITLE
feat(mcp): add skillboss mcp server

### DIFF
--- a/packages/other-tools-and-integrations/skillboss-mcp.json
+++ b/packages/other-tools-and-integrations/skillboss-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "SkillBoss",
+  "packageName": "@skillboss/mcp-server",
+  "description": "The complete tool store for AI agents. Provides instant access to 100+ services including AI models, image/video generation, web scraping, payments, databases, and more with a single API key.",
+  "url": "https://skillboss.co",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {
+    "SKILLBOSS_API_KEY": {
+      "description": "API key for SkillBoss service",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the `@skillboss/mcp-server` to the registry based on the details provided in Issue #163.

Closes #163 submitted by @xiaoyinqu.

Thanks for the contribution!