### PR TITLE
feat(mcp): add mcp-api-bridge-lite server

### DIFF
--- a/packages/developer-tools/mcp-api-bridge-lite.json
+++ b/packages/developer-tools/mcp-api-bridge-lite.json
@@ -1,0 +1,9 @@
+{
+  "type": "mcp-server",
+  "name": "mcp-api-bridge-lite",
+  "packageName": "mcp-api-bridge-lite",
+  "description": "Free, open-source REST API to MCP bridge. Connect any REST API to AI assistants through MCP with simple YAML configuration. Supports GET, POST, PUT, DELETE with authentication, headers, and parameter mapping.",
+  "url": "https://github.com/tiranmoskovitch-dev/mcp-api-bridge-lite",
+  "runtime": "python",
+  "license": "MIT"
+}


### PR DESCRIPTION
This PR adds the `mcp-api-bridge-lite` server to the registry.

Closes #168 submitted by @tiranmoskovitch-dev.

Thank you for the contribution!