### PR TITLE
ci: fix npm publish E403 by adding fail-safe version bump

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,13 @@ jobs:
           git config --global user.email "dev@toolsdk.ai"
 
       - name: Publish
-        run: npm publish --access public
+        run: |
+          # If publish fails due to E403 (version already exists), bump version and try again
+          npm publish --access public || (
+            echo "Publish failed, attempting to bump version..."
+            npm version patch --no-git-tag-version
+            npm publish --access public
+          )
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
If the `package.json` version was already published to NPM, the CI previously failed with a 403 error. 

This PR wraps the `npm publish` step in a fail-safe: if the publish fails (usually due to a version conflict), it will automatically bump the patch version locally and retry the publish immediately, ensuring the CI pipeline doesn't break.