### PR TITLE
Add defi-mcp — DeFi & crypto MCP server

### DIFF
--- a/packages/finance-fintech/defi-mcp.json
+++ b/packages/finance-fintech/defi-mcp.json
@@ -1,0 +1,9 @@
+{
+  "type": "mcp-server",
+  "name": "defi-mcp",
+  "packageName": "defi-mcp",
+  "description": "DeFi & crypto MCP server with 12 tools: token prices, gas estimates, DEX pool analytics, ENS resolution, trending tokens, DeFi protocol TVL, yield opportunities, and historical price data. Works with Claude Desktop and Cursor.",
+  "url": "https://github.com/OzorOwn/defi-mcp",
+  "runtime": "node",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds **defi-mcp** to the finance-fintech category.

**defi-mcp** is an MCP server providing 12 DeFi/crypto tools:
- Token prices (single + batch) with 24h change
- Gas price estimates (Ethereum)
- DEX pool analytics (Uniswap, etc.)
- ENS name resolution
- Trending tokens (CoinGecko)
- DeFi protocol TVL rankings
- Yield opportunity discovery
- Historical price data

Works with Claude Desktop, Cursor, and any MCP-compatible client.

- **GitHub**: https://github.com/OzorOwn/defi-mcp
- **Runtime**: Node.js
- **License**: MIT