### PR TITLE
Add ProofBets MCP Server to finance-fintech

### DIFF
--- a/packages/finance-fintech/toolsdk-remote-proofbets-mcp.json
+++ b/packages/finance-fintech/toolsdk-remote-proofbets-mcp.json
@@ -1,21 +1,21 @@
 {
   "type": "mcp-server",
-  "packageName": "proofbets-mcp",
+  "name": "ProofBets MCP Server",
+  "packageName": "@toolsdk-remote/proofbets-mcp",
   "description": "Casino intelligence with 13 tools: search 50+ crypto casinos, verify bonus codes, calculate EV, compare P2P prediction markets (Polymarket, Kalshi, Azuro), and on-chain wallet verification",
   "url": "https://github.com/proofbets/proofbets-mcp",
-  "homepage": "https://proofbets.com/developers/",
   "runtime": "node",
   "license": "MIT",
-  "name": "ProofBets MCP Server",
-  "vendor": "ProofBets",
-  "transport": {
-    "type": "sse",
-    "url": "https://proofbets.com/api/mcp/"
-  },
   "env": {
     "PROOFBETS_API_KEY": {
-      "description": "Optional API key for higher rate limits (100 req/min vs 20 req/min free tier)",
+      "description": "Optional API key for higher rate limits",
       "required": false
     }
-  }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://proofbets.com/api/mcp/"
+    }
+  ]
 }


### PR DESCRIPTION
Adding ProofBets MCP Server to the finance-fintech category.

13 MCP tools covering crypto casino data, bonus verification, EV calculation, and P2P prediction market comparisons (Polymarket, Kalshi, Azuro, BetDEX).

- SSE transport: https://proofbets.com/api/mcp/
- GitHub: https://github.com/proofbets/proofbets-mcp
- Free tier: 20 req/min (no key required)
- OpenAPI 3.1 spec: https://proofbets.com/openapi.yaml