### PR TITLE
Add GEOScore MCP server

### DIFF
--- a/packages/marketing/geoscore-mcp.json
+++ b/packages/marketing/geoscore-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "GEOScore",
+  "packageName": "geoscore-mcp",
+  "description": "AI search optimization (GEO). Scan websites for AI search readiness, generate llms.txt, Schema.org fixes, meta tag optimizations.",
+  "url": "https://github.com/henu-wang/geoscore-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "GEOSCORE_API_KEY": {
+      "description": "API key for GEOScore service",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add GEOScore MCP server to the `marketing` category
- GEOScore is an AI search optimization (GEO) tool that scans websites for AI search readiness, generates llms.txt, Schema.org fixes, and meta tag optimizations
- Package: `geoscore-mcp` (npm), Runtime: node, License: MIT

## Links
- GitHub: https://github.com/henu-wang/geoscore-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)