### PR TITLE
Add ProofBets MCP Server to registry

### DIFF
--- a/packages/finance-fintech/proofbets.json
+++ b/packages/finance-fintech/proofbets.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "proofbets",
+  "description": "Query verified crypto casino data, bonus codes, prediction market fees, and World Cup 2026 odds",
+  "url": "https://github.com/vjrmuc/proofbets/tree/main/mcp-server",
+  "homepage": "https://proofbets.com/developers/",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {},
+  "name": "ProofBets"
+}


### PR DESCRIPTION
## What I'm adding
ProofBets MCP server with 13 tools for crypto gambling data. Unique features: on-chain casino wallet verification, live bonus code monitoring with confidence scoring, prediction market fee comparison across 7 platforms. Free API with OpenAPI 3.1 spec.

## Checklist
- [x] Follows registry schema
- [x] Link is working
- [x] Category is accurate