### PR TITLE
Add agentic-ads MCP server

### DIFF
--- a/packages/uncategorized/agentic-ads.json
+++ b/packages/uncategorized/agentic-ads.json
@@ -1,0 +1,9 @@
+{
+  "type": "mcp-server",
+  "name": "agentic-ads",
+  "packageName": "agentic-ads",
+  "description": "Affiliate marketing SDK for MCP servers. Earn USDC on Base for each click on sponsored contextual recommendations. Integrates via MCP tool calls.",
+  "url": "https://github.com/nicofains1/agentic-ads",
+  "runtime": "node",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds **agentic-ads** to the registry — the first affiliate marketing SDK for MCP servers.

- **What it does**: Lets MCP server developers earn USDC on Base by serving contextual sponsored recommendations alongside organic results
- **Live**: https://agentic-ads-production.up.railway.app
- **MCP endpoint**: https://agentic-ads-production.up.railway.app/mcp
- **270+ tests passing**
- **Runtime**: Node.js
- **License**: MIT

Source: https://github.com/nicofains1/agentic-ads