### PR TITLE
Add Omnis Venture Intelligence MCP

### DIFF
--- a/packages/uncategorized/toolsdk-remote-com-bamboosnow-omnis-venture-intelligence.json
+++ b/packages/uncategorized/toolsdk-remote-com-bamboosnow-omnis-venture-intelligence.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "packageName": "@toolsdk-remote/com-bamboosnow-omnis-venture-intelligence",
+  "name": "Omnis Venture Intelligence MCP",
+  "description": "Hosted MCP and API for startup discovery, company scoring, venture monitoring, and private workspace automation for investors and autonomous agents.",
+  "url": "https://github.com/HCS412/ventureautomated",
+  "runtime": "node",
+  "license": "mit",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.bamboosnow.co/api/v1/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n- add Omnis Venture Intelligence MCP as a hosted remote server\n- point the registry entry at the live Streamable HTTP endpoint on bamboosnow.co\n- include the public GitHub repo as the canonical source\n\n## Notes\n- Remote endpoint: https://www.bamboosnow.co/api/v1/mcp\n- Public product page: https://www.bamboosnow.co/venture-intelligence-mcp-server\n- Public MCP metadata: https://www.bamboosnow.co/.well-known/mcp-server.json