### PR TITLE
Add 402.bot Discovery Oracle remote MCP server

### DIFF
--- a/packages/developer-tools/discovery-oracle-402bot.json
+++ b/packages/developer-tools/discovery-oracle-402bot.json
@@ -1,6 +1,7 @@
 {
   "type": "mcp-server",
   "name": "402.bot Discovery Oracle",
+  "logo": "https://api.402.bot/brand/402bot-logo-400.png",
   "packageName": "@toolsdk-remote/discovery-oracle-402bot",
   "description": "Discover live agent APIs, ranked endpoints, trust, payment telemetry, and x402 surfaces.",
   "url": "https://github.com/sam00101011/402.bot-public",


### PR DESCRIPTION
Adds 402.bot Discovery Oracle as a public remote MCP server backed by https://api.402.bot/mcp.\n\nPublic repo: https://github.com/sam00101011/402.bot-public\nSetup/docs: https://api.402.bot/mcp/setup\nllms.txt: https://402.bot/llms.txt