### PR TITLE
Add RustChain MCP server to Finance & Fintech

### DIFF
--- a/packages/finance-fintech/rustchain-mcp.json
+++ b/packages/finance-fintech/rustchain-mcp.json
@@ -5,9 +5,5 @@
   "url": "https://github.com/Scottcjn/rustchain-mcp",
   "runtime": "python",
   "license": "MIT",
-  "env": {
-    "RUSTCHAIN_NODE_URL": "https://rustchain.org",
-    "BOTTUBE_API_URL": "https://bottube.ai"
-  },
   "name": "RustChain MCP"
 }


### PR DESCRIPTION
## Add RustChain MCP Server

Adds `rustchain-mcp` package to the Finance & Fintech category.

**What it does:**
- MCP server for the RustChain blockchain (RTC token) and BoTTube video platform
- 15 tools + 3 resources for AI agents
- Mining attestation, wallet management, bounty hunting, video publishing
- Proof-of-Antiquity consensus rewards vintage hardware

**Install:** `pip install rustchain-mcp`

**Links:**
- GitHub: https://github.com/Scottcjn/rustchain-mcp
- PyPI: https://pypi.org/project/rustchain-mcp/