### PR TITLE
Add Xquik X/Twitter data platform MCP server

### DIFF
--- a/packages/search-data-extraction/xquik.json
+++ b/packages/search-data-extraction/xquik.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "packageName": "xquik",
+  "name": "Xquik X/Twitter Data Platform",
+  "description": "X/Twitter data platform — MCP server, 76 REST API endpoints, 20 extraction tools",
+  "url": "https://github.com/Xquik-dev/x-twitter-scraper",
+  "runtime": "node",
+  "license": "UNLICENSED",
+  "env": {
+    "XQUIK_API_KEY": {
+      "description": "API key for authenticating with the Xquik MCP server",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
Add Xquik MCP server to the search-data-extraction category.

X/Twitter data platform — MCP server, 76 REST API endpoints, 20 extraction tools.

- **Package file**: `packages/search-data-extraction/xquik.json`
- **URL**: https://github.com/Xquik-dev/x-twitter-scraper

Disclosure: I am the developer of Xquik.