### PR TITLE
docs(registry): improve contribution guide and MCP Gateway documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ fetch-official-mcp:
 	bun scripts/official-registry/index.ts
 
 # Validate a single MCP Server JSON file
-# Usage: make validate FILE=packages/aggregators/1mcp-agent.json
+# Usage: make validate packages/aggregators/1mcp-agent.json
 validate:
-	bun scripts/validate-package.ts $(FILE)
+	bun scripts/validate-package.ts $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+
+# Swallow positional args so make doesn't treat them as targets
+%:
+	@:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,28 @@ curl -X POST http://localhost:3003/api/v1/packages/run \
   }'
 ```
 
+#### 🔌 MCP Gateway (Streamable HTTP Proxy)
+
+The registry also acts as an **MCP Gateway** — any registered package can be accessed as a standard [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) endpoint, even if the original server is STDIO-only.
+
+**Endpoint:** `POST /mcp/<packageName>`
+
+Pass environment variables via `x-mcp-env-*` headers:
+
+```bash
+curl -X POST http://localhost:3003/mcp/@modelcontextprotocol/server-github \
+  -H "Content-Type: application/json" \
+  -H "x-mcp-env-GITHUB_PERSONAL_ACCESS_TOKEN: ghp_your_token" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+The server returns a `mcp-session-id` header — include it in subsequent requests to reuse the session (sessions expire after 30 min).
+
+This is useful for:
+- **Protocol Bridging** — Expose local STDIO servers as remote HTTP endpoints
+- **Centralized Access** — Give AI agents a single HTTP gateway to all MCP tools
+- **Client Compatibility** — Connect from any MCP client that supports Streamable HTTP
+
 <details>
 <summary><strong>Alternative: Use as Registry SDK (Data Only)</strong></summary>
 
@@ -274,45 +296,9 @@ const searchTool = await searchMCP.getAISDKTool('tavily-search');
 
 ## Contribute Your MCP Server
 
-Help grow the ecosystem! Share your AI tools, plugins, and integrations with the community.
-
-### Quick Submission
+Want to add your MCP server to the registry? Check out our [Contributing Guide](./docs/CONTRIBUTING.md) for the full submission process, JSON schema reference, and examples (including remote servers and OAuth 2.1).
 
 [![Watch the video](https://img.youtube.com/vi/J_oaDtCoVVo/hqdefault.jpg)](https://www.youtube.com/watch?v=J_oaDtCoVVo)
-
-1. [Fork this repository](https://github.com/toolsdk-ai/toolsdk-mcp-registry/fork)
-2. Create `your-mcp-server.json` in [packages/uncategorized](./packages/uncategorized) (or the best matching category folder)
-3. Submit a PR
-
-Config Example:
-
-```json
-{
-  "type": "mcp-server",
-  "name": "Github",
-  "packageName": "@modelcontextprotocol/server-github",
-  "description": "MCP server for using the GitHub API",
-  "url": "https://github.com/modelcontextprotocol/servers/blob/main/src/github",
-  "runtime": "node",
-  "license": "MIT",
-  "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": {
-      "description": "Personal access token for GitHub API access",
-      "required": true
-    }
-  }
-}
-```
-
-Your MCP server will be:
-- ✅ Listed in the registry
-- 🔍 Searchable via REST API
-- 📦 Available in npm package
-- 🌐 Featured on [ToolSDK.ai](https://toolsdk.ai)
-
-📖 **Source of truth (schema, fields, remotes, OAuth)**: [CONTRIBUTING.md](./CONTRIBUTING.md)
-
-📚 Additional docs: [docs/guide.md](./docs/guide.md)
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,11 +7,13 @@ Thanks for your interest in contributing to ToolSDK MCP Registry! 🎉 Your help
 Want to add a new MCP server to our registry? It's easy! Just follow these steps:
 
 1. **Fork this repo** 🍴 - Click the fork button at the top right of this page
-2. **Create a JSON file** 📄 - Add a new file named `your-mcp-server.json` in the [packages/uncategorized](./packages/uncategorized) folder. AI will automatically categorize it later.
+2. **Create a JSON file** 📄 - Add a new file named `your-mcp-server.json` in the [packages/uncategorized](../packages/uncategorized) folder. AI will automatically categorize it later.
 3. **Fill in the details** ✍️ - Use the format below.
 4. **Submit a pull request** 🚀 - We'll review it and merge it in!
 
 If you know which category your server fits into, feel free to put it in the appropriate folder instead of `uncategorized`.
+
+### Minimal Example
 
 ```json
 {
@@ -31,28 +33,43 @@ If you know which category your server fits into, feel free to put it in the app
 }
 ```
 
-> Every file that enters this repository will be validated by Zod. You can open [common-schema.ts](./src/shared/schemas/common-schema.ts) to see the definition of the Zod schema.
+> Every file that enters this repository will be validated by Zod. You can open [common-schema.ts](../src/shared/schemas/common-schema.ts) to see the definition of the Zod schema.
 
-Here's a list of fields you can use in your MCP server configuration:
+### Validate Locally
 
-| Field            | Type   | Required | Description                                                                                               |
-| ---------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------- |
-| `type`           | string | Yes      | Must be `"mcp-server"`                                                                                    |
-| `name`           | string | No       | Custom display name. If not provided, package name will be used                                           |
-| `packageName`    | string | Yes      | Name of the package (e.g. npm, PyPI, Maven package name)                                                  |
-| `packageVersion` | string | No       | Version of the package. If not provided, latest version will be used                                      |
-| `description`    | string | No       | Description of the MCP server                                                                             |
-| `url`            | string | No       | GitHub repository URL                                                                                     |
-| `runtime`        | string | Yes      | Runtime environment: `"node"`, `"python"`, `"java"`, `"go"`                                               |
-| `license`        | string | No       | Open source license (e.g. MIT, AGPL, GPL)                                                                 |
-| `env`            | object | Yes       | Environment variables required by the server. If no env is needed, you can fill in an empty object `{}`    |
-| `logo`           | string | No       | URL to custom logo image                                                                                  |
-| `remotes`        | array  | No       | Remote server endpoints for hosted MCP servers (see [Remote MCP Servers](#-remote-mcp-servers) below)     |
+You can validate your JSON file before submitting a PR:
 
-Each environment variable in the env object should have:
+```bash
+make validate packages/uncategorized/your-mcp-server.json
+```
 
-- `description`: A brief description of what the variable is used for
-- `required`: Boolean indicating if the variable is required
+## 📋 JSON Schema Reference
+
+Here's the complete list of fields you can use in your MCP server configuration:
+
+| Field            | Type     | Required | Description                                                                                                |
+| ---------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `type`           | string   | Yes      | Must be `"mcp-server"`                                                                                     |
+| `runtime`        | string   | Yes      | Runtime environment: `"node"`, `"python"`, `"java"`, `"go"`, `"docker"`                                    |
+| `packageName`    | string   | Yes      | Name of the package (e.g. npm, PyPI, Maven package name, or Docker image)                                  |
+| `packageVersion` | string   | No       | Version of the package. If not provided, latest version will be used                                       |
+| `bin`            | string   | No       | Binary command to run the MCP server. If not provided, the package name will be used                       |
+| `binArgs`        | string[] | No       | Arguments to pass to the binary command. Defaults to an empty array                                        |
+| `key`            | string   | No       | Unique key for URL and slug. If not provided, the package name will be used                                |
+| `name`           | string   | No       | Custom display name. If not provided, the package name will be used                                        |
+| `description`    | string   | No       | Description of the MCP server                                                                              |
+| `readme`         | string   | No       | URL to the README file. If not provided, the package URL will be used                                      |
+| `url`            | string   | No       | GitHub repository URL                                                                                      |
+| `license`        | string   | No       | Open source license (e.g. MIT, AGPL, GPL)                                                                  |
+| `logo`           | string   | No       | URL to custom logo image. If the URL is GitHub and logo is not set, the GitHub avatar will be used         |
+| `author`         | string   | No       | Author name or ToolSDK.ai developer ID                                                                     |
+| `env`            | object   | No       | Environment variables required by the server. Use an empty object `{}` if none are needed                  |
+| `remotes`        | array    | No       | Remote server endpoints for hosted MCP servers (see [Remote MCP Servers](#-remote-mcp-servers) below)      |
+
+Each environment variable in the `env` object should have:
+
+- `description` (string): A brief description of what the variable is used for
+- `required` (boolean): Whether the variable is required
 
 ## 🌐 Remote MCP Servers
 
@@ -65,6 +82,7 @@ If your MCP server supports remote hosting via Streamable HTTP transport, you ca
   "packageName": "github-mcp",
   "description": "A GitHub automation tool with remote hosting support",
   "runtime": "node",
+  "env": {},
   "remotes": [
     {
       "type": "streamable-http",
@@ -85,12 +103,14 @@ For MCP servers that require OAuth 2.1 authentication, add the `auth` configurat
   "packageName": "github-mcp",
   "description": "GitHub MCP with OAuth authentication",
   "runtime": "node",
+  "env": {},
   "remotes": [
     {
       "type": "streamable-http",
       "url": "https://your-server.com/mcp",
       "auth": {
-        "type": "oauth2"
+        "type": "oauth2",
+        "scopes": ["repo", "user"]
       }
     }
   ]
@@ -99,20 +119,19 @@ For MCP servers that require OAuth 2.1 authentication, add the `auth` configurat
 
 ### Remote Configuration Fields
 
-| Field         | Type   | Required | Description                                              |
-| ------------- | ------ | -------- | -------------------------------------------------------- |
-| `type`        | string | Yes      | Transport type. Currently only `"streamable-http"`       |
-| `url`         | string | Yes      | Remote server endpoint URL                               |
-| `auth`        | object | No       | Authentication configuration                             |
-| `auth.type`   | string | Yes*     | Authentication type. Currently only `"oauth2"`           |
+| Field         | Type     | Required | Description                                              |
+| ------------- | -------- | -------- | -------------------------------------------------------- |
+| `type`        | string   | Yes      | Transport type. Currently only `"streamable-http"`       |
+| `url`         | string   | Yes      | Remote server endpoint URL (must be a valid URL)         |
+| `auth`        | object   | No       | Authentication configuration                             |
+| `auth.type`   | string   | Yes*     | Authentication type. Currently only `"oauth2"`           |
+| `auth.scopes` | string[] | No       | OAuth scopes to request                                  |
 
 > *Required when `auth` object is provided
 
-For more detail please see [the guide](./docs/guide.md).
-
 ## 💻 Code Contributions
 
-We warmly welcome contributions to both our **code** and **documentation**.  
+We warmly welcome contributions to both our **code** and **documentation**.
 Whether you're fixing a small bug, improving performance, or adding an exciting new feature, your efforts are valued. 💪
 
 ### How You Can Contribute
@@ -122,7 +141,7 @@ Whether you're fixing a small bug, improving performance, or adding an exciting 
 - 📚 **Improve documentation** — make it clearer and more complete
 - ⚡ **Optimize code** — enhance performance and readability
 
-Don't worry about perfection — **just submit your work**!  
+Don't worry about perfection — **just submit your work**!
 Our team will review, provide feedback, and help polish it before merging. 🙌
 
 > 💡 Tip: Even small changes matter — every pull request counts!
@@ -131,4 +150,4 @@ Our team will review, provide feedback, and help polish it before merging. 🙌
 
 Your contributions help build a better ecosystem for everyone working with Model Context Protocol servers. Every addition matters! ❤️
 
-For detailed technical information, check out our [complete guide](./docs/guide.md).
+For detailed technical information, check out our [Development Guide](./DEVELOPMENT.md) and [Guide](./guide.md).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -472,9 +472,10 @@ This project follows **Domain-Driven Design (DDD)** architecture with **Service 
     │   └── index.ts  # Server initialization and route registration
     ├── domains/      # Business domains (core logic)
     │   ├── config/   # Configuration management
-    │   ├── executor/ # Tool execution (local-executor, sandbox-executor)
-    │   ├── package/  # Package management (SO, handler, routes)
-    │   ├── sandbox/  # Sandbox management (pooling, providers)
+    │   ├── executor/    # Tool execution (local-executor, sandbox-executor)
+    │   ├── mcp-gateway/ # MCP Gateway — proxies packages as Streamable HTTP endpoints
+    │   ├── package/     # Package management (SO, handler, routes)
+    │   ├── sandbox/     # Sandbox management (pooling, providers)
     │   └── search/   # Search service integration
     └── shared/       # Shared infrastructure
         ├── config/   # Environment configuration (environment.ts)

--- a/docs/_templates/README.tpl.md
+++ b/docs/_templates/README.tpl.md
@@ -107,6 +107,28 @@ curl -X POST http://localhost:3003/api/v1/packages/run \
   }'
 ```
 
+#### 🔌 MCP Gateway (Streamable HTTP Proxy)
+
+The registry also acts as an **MCP Gateway** — any registered package can be accessed as a standard [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) endpoint, even if the original server is STDIO-only.
+
+**Endpoint:** `POST /mcp/<packageName>`
+
+Pass environment variables via `x-mcp-env-*` headers:
+
+```bash
+curl -X POST http://localhost:3003/mcp/@modelcontextprotocol/server-github \
+  -H "Content-Type: application/json" \
+  -H "x-mcp-env-GITHUB_PERSONAL_ACCESS_TOKEN: ghp_your_token" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+The server returns a `mcp-session-id` header — include it in subsequent requests to reuse the session (sessions expire after 30 min).
+
+This is useful for:
+- **Protocol Bridging** — Expose local STDIO servers as remote HTTP endpoints
+- **Centralized Access** — Give AI agents a single HTTP gateway to all MCP tools
+- **Client Compatibility** — Connect from any MCP client that supports Streamable HTTP
+
 <details>
 <summary><strong>Alternative: Use as Registry SDK (Data Only)</strong></summary>
 
@@ -274,45 +296,9 @@ const searchTool = await searchMCP.getAISDKTool('tavily-search');
 
 ## Contribute Your MCP Server
 
-Help grow the ecosystem! Share your AI tools, plugins, and integrations with the community.
-
-### Quick Submission
+Want to add your MCP server to the registry? Check out our [Contributing Guide](./docs/CONTRIBUTING.md) for the full submission process, JSON schema reference, and examples (including remote servers and OAuth 2.1).
 
 [![Watch the video](https://img.youtube.com/vi/J_oaDtCoVVo/hqdefault.jpg)](https://www.youtube.com/watch?v=J_oaDtCoVVo)
-
-1. [Fork this repository](https://github.com/toolsdk-ai/toolsdk-mcp-registry/fork)
-2. Create `your-mcp-server.json` in [packages/uncategorized](./packages/uncategorized) (or the best matching category folder)
-3. Submit a PR
-
-Config Example:
-
-```json
-{
-  "type": "mcp-server",
-  "name": "Github",
-  "packageName": "@modelcontextprotocol/server-github",
-  "description": "MCP server for using the GitHub API",
-  "url": "https://github.com/modelcontextprotocol/servers/blob/main/src/github",
-  "runtime": "node",
-  "license": "MIT",
-  "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": {
-      "description": "Personal access token for GitHub API access",
-      "required": true
-    }
-  }
-}
-```
-
-Your MCP server will be:
-- ✅ Listed in the registry
-- 🔍 Searchable via REST API
-- 📦 Available in npm package
-- 🌐 Featured on [ToolSDK.ai](https://toolsdk.ai)
-
-📖 **Source of truth (schema, fields, remotes, OAuth)**: [CONTRIBUTING.md](./CONTRIBUTING.md)
-
-📚 Additional docs: [docs/guide.md](./docs/guide.md)
 
 ---
 

--- a/scripts/validate-package.ts
+++ b/scripts/validate-package.ts
@@ -3,103 +3,225 @@
  *
  * Usage:
  *   bun scripts/validate-package.ts <path-to-json>
+ *   make validate <path-to-json>
  *
  * Examples:
  *   bun scripts/validate-package.ts packages/aggregators/1mcp-agent.json
- *   bun scripts/validate-package.ts packages/finance-fintech/defi-mcp.json
+ *   make validate packages/finance-fintech/defi-mcp.json
+ *
+ * What it checks:
+ *   1. File exists and is valid JSON
+ *   2. JSON structure matches the Zod schema (MCPServerPackageConfigSchema)
+ *   3. (Optional) Connects to the MCP server and lists tools
+ *
+ * Flags:
+ *   --schema-only   Skip the connection test, only validate JSON schema
  */
 
 import fs from "node:fs";
+import path from "node:path";
+import { z } from "zod";
 import {
   getMcpClient,
   MCPServerPackageConfigSchema,
   withTimeout,
 } from "../src/shared/scripts-helpers";
 
-const filePath = process.argv[2];
+// ── CLI args ──────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const schemaOnly = args.includes("--schema-only");
+const filePath = args.find((a) => !a.startsWith("--"));
 
 if (!filePath) {
-  console.error("Usage: bun scripts/validate-package.ts <path-to-json>");
-  console.error("Example: bun scripts/validate-package.ts packages/aggregators/1mcp-agent.json");
+  console.error("Usage: bun scripts/validate-package.ts <path-to-json> [--schema-only]");
+  console.error("");
+  console.error("Examples:");
+  console.error("  bun scripts/validate-package.ts packages/aggregators/1mcp-agent.json");
+  console.error("  make validate packages/finance-fintech/defi-mcp.json");
+  console.error("");
+  console.error("Flags:");
+  console.error("  --schema-only   Only validate JSON schema, skip connection test");
   process.exit(1);
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────
+function fail(message: string, detail?: string): never {
+  console.error(`\n❌ ${message}`);
+  if (detail) console.error(`   ${detail}`);
+  process.exit(1);
+}
+
+function info(label: string, value: string) {
+  console.log(`   ${label.padEnd(14)}: ${value}`);
+}
+
+/**
+ * Format Zod errors into human-readable lines.
+ */
+function formatZodErrors(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+    switch (issue.code) {
+      case "invalid_type":
+        return `  • "${path}": expected ${issue.expected}, got ${issue.received}`;
+      case "invalid_enum_value":
+        return `  • "${path}": must be one of [${(issue.options as string[]).join(", ")}], got "${issue.received}"`;
+      case "unrecognized_keys":
+        return `  • "${path}": unrecognized key(s): ${issue.keys.join(", ")}`;
+      case "invalid_string":
+        if (issue.validation === "url") {
+          return `  • "${path}": must be a valid URL`;
+        }
+        return `  • "${path}": invalid string (${issue.validation})`;
+      default:
+        return `  • "${path}": ${issue.message}`;
+    }
+  });
+}
+
+// ── Step 0: File existence ────────────────────────────────────────────
+console.log(`\n🔍 Validating: ${filePath}\n`);
 
 if (!fs.existsSync(filePath)) {
-  console.error(`File not found: ${filePath}`);
-  process.exit(1);
+  fail("File not found", filePath);
 }
 
-async function main() {
-  console.log(`\n🔍 Validating: ${filePath}\n`);
+const ext = path.extname(filePath).toLowerCase();
+if (ext !== ".json") {
+  fail(`Expected a .json file, got "${ext}"`, filePath);
+}
 
-  // Step 1: Parse and schema-validate the JSON
-  let config: ReturnType<typeof MCPServerPackageConfigSchema.parse>;
-  try {
-    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    config = MCPServerPackageConfigSchema.parse(raw);
-    console.log("✅ Schema validation passed");
-  } catch (e) {
-    console.error("❌ Schema validation failed:");
-    console.error((e as Error).message);
+// ── Step 1: JSON parse ────────────────────────────────────────────────
+let raw: unknown;
+try {
+  const content = fs.readFileSync(filePath, "utf-8");
+
+  // Check for empty file
+  if (content.trim().length === 0) {
+    fail("File is empty");
+  }
+
+  raw = JSON.parse(content);
+} catch (e) {
+  if (e instanceof SyntaxError) {
+    fail("Invalid JSON syntax", e.message);
+  }
+  fail("Failed to read file", (e as Error).message);
+}
+
+// Basic structural check before Zod
+if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+  fail("JSON root must be an object, got " + (Array.isArray(raw) ? "array" : typeof raw));
+}
+
+console.log("✅ Valid JSON");
+
+// ── Step 2: Zod schema validation ─────────────────────────────────────
+type MCPConfig = z.infer<typeof MCPServerPackageConfigSchema>;
+let config: MCPConfig;
+
+try {
+  config = MCPServerPackageConfigSchema.parse(raw);
+  console.log("✅ Schema validation passed");
+} catch (e) {
+  if (e instanceof z.ZodError) {
+    console.error("\n❌ Schema validation failed:\n");
+    const lines = formatZodErrors(e);
+    for (const line of lines) {
+      console.error(line);
+    }
+    console.error(
+      "\n💡 See the full schema: src/shared/schemas/common-schema.ts (MCPServerPackageConfigSchema)",
+    );
     process.exit(1);
   }
+  fail("Schema validation failed", (e as Error).message);
+}
 
-  console.log(`   runtime     : ${config.runtime}`);
-  console.log(`   packageName : ${config.packageName}`);
-  if (config.packageVersion) console.log(`   version     : ${config.packageVersion}`);
-  if (config.remotes?.length) {
-    console.log(`   remotes     : ${config.remotes.map((r) => r.url).join(", ")}`);
+// ── Step 3: Print summary ─────────────────────────────────────────────
+console.log("");
+info("type", config.type);
+info("runtime", config.runtime);
+info("packageName", config.packageName);
+if (config.packageVersion) info("version", config.packageVersion);
+if (config.name) info("name", config.name);
+if (config.key) info("key", config.key);
+if (config.license) info("license", config.license);
+if (config.bin) info("bin", config.bin);
+if (config.binArgs?.length) info("binArgs", config.binArgs.join(" "));
+if (config.url) info("url", config.url);
+if (config.author) info("author", config.author);
+
+const envKeys = Object.keys(config.env || {});
+if (envKeys.length > 0) {
+  const required = envKeys.filter((k) => config.env?.[k]?.required);
+  info("env", `${envKeys.length} var(s), ${required.length} required`);
+  for (const key of envKeys) {
+    const envDef = config.env?.[key];
+    console.log(
+      `     ${envDef?.required ? "🔑" : "  "} ${key} — ${envDef?.description || "(no description)"}`,
+    );
   }
+}
 
-  // Step 2: Try to connect and list tools
-  const hasRemotes = config.remotes && config.remotes.length > 0;
-  const canConnect = config.runtime === "node" || config.runtime === "docker" || hasRemotes;
+if (config.remotes?.length) {
+  info("remotes", `${config.remotes.length} endpoint(s)`);
+  for (const remote of config.remotes) {
+    console.log(`      → ${remote.url}${remote.auth ? ` (auth: ${remote.auth.type})` : ""}`);
+  }
+}
 
-  if (!canConnect) {
-    console.log(`\n⚠️  Runtime "${config.runtime}" is not auto-connectable (python/java/go).`);
+// ── Step 4: Connection test (optional) ────────────────────────────────
+if (schemaOnly) {
+  console.log("\n✅ Schema-only validation complete (connection test skipped)");
+  process.exit(0);
+}
+
+const hasRemotes = config.remotes && config.remotes.length > 0;
+const canConnect = config.runtime === "node" || config.runtime === "docker" || hasRemotes;
+
+if (!canConnect) {
+  console.log(`\n⚠️  Runtime "${config.runtime}" is not auto-connectable (python/java/go).`);
+  console.log("   Schema is valid. Connection test skipped.");
+  process.exit(0);
+}
+
+// For node runtime, check node_modules first
+if (config.runtime === "node" && !hasRemotes) {
+  const pkgJsonPath = `node_modules/${config.packageName}/package.json`;
+  if (!fs.existsSync(pkgJsonPath)) {
+    console.log(`\n⚠️  Package not installed: ${config.packageName}`);
+    console.log(`   Run: pnpm add ${config.packageName}`);
     console.log("   Schema is valid. Connection test skipped.");
     process.exit(0);
   }
-
-  // For node runtime, check node_modules first
-  if (config.runtime === "node" && !hasRemotes) {
-    const pkgJsonPath = `node_modules/${config.packageName}/package.json`;
-    if (!fs.existsSync(pkgJsonPath)) {
-      console.log(`\n⚠️  Package not installed: ${config.packageName}`);
-      console.log(`   Run: pnpm add ${config.packageName}`);
-      console.log("   Schema is valid. Connection test skipped.");
-      process.exit(0);
-    }
-  }
-
-  const mockEnv: Record<string, string> = {};
-  for (const key of Object.keys(config.env || {})) {
-    mockEnv[key] = "MOCK";
-  }
-
-  console.log("\n🔌 Connecting to MCP server...");
-  try {
-    const mcpClient = await withTimeout(8000, getMcpClient(config, mockEnv));
-    const toolsResult = await mcpClient.client.listTools();
-    await mcpClient.closeConnection();
-
-    if (toolsResult.tools.length === 0) {
-      console.error("\n❌ Connection succeeded but no tools returned — validated: false");
-      process.exit(1);
-    }
-
-    console.log(`\n✅ validated: true — ${toolsResult.tools.length} tool(s) found:`);
-    for (const tool of toolsResult.tools) {
-      console.log(
-        `   • ${tool.name}${tool.description ? ` — ${tool.description.slice(0, 80)}` : ""}`,
-      );
-    }
-    process.exit(0);
-  } catch (e) {
-    console.error("\n❌ Connection failed — validated: false");
-    console.error("  ", (e as Error).message);
-    process.exit(1);
-  }
 }
 
-await main();
+const mockEnv: Record<string, string> = {};
+for (const key of Object.keys(config.env || {})) {
+  mockEnv[key] = "MOCK";
+}
+
+console.log("\n🔌 Connecting to MCP server...");
+try {
+  const mcpClient = await withTimeout(8000, getMcpClient(config, mockEnv));
+  const toolsResult = await mcpClient.client.listTools();
+  await mcpClient.closeConnection();
+
+  if (toolsResult.tools.length === 0) {
+    console.error("\n❌ Connection succeeded but no tools returned — validated: false");
+    process.exit(1);
+  }
+
+  console.log(`\n✅ validated: true — ${toolsResult.tools.length} tool(s) found:`);
+  for (const tool of toolsResult.tools) {
+    console.log(
+      `   • ${tool.name}${tool.description ? ` — ${tool.description.slice(0, 80)}` : ""}`,
+    );
+  }
+  process.exit(0);
+} catch (e) {
+  console.error("\n❌ Connection failed — validated: false");
+  console.error("  ", (e as Error).message);
+  process.exit(1);
+}


### PR DESCRIPTION
- Update Makefile to support positional arguments for validate command without FILE variable
- Add MCP Gateway section to README explaining Streamable HTTP proxy functionality
- Consolidate contribution instructions into dedicated CONTRIBUTING.md guide
- Add local validation instructions and complete JSON schema reference table
- Improve documentation links and fix relative paths in docs
- Add examples for remote MCP servers and OAuth 2.1 authentication
- Simplify README contribution section with link to comprehensive guide
- Enhance developer experience with clearer setup and validation workflows