### PR TITLE
Add Frihet MCP server

### DIFF
--- a/packages/finance-fintech/frihet-mcp.json
+++ b/packages/finance-fintech/frihet-mcp.json
@@ -3,7 +3,7 @@
   "name": "Frihet",
   "packageName": "@toolsdk-remote/frihet-mcp-server",
   "description": "AI-native business management MCP server with 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance (VeriFactu). Supports multi-currency (40 currencies), OCR, Stripe Connect, and webhooks.",
-  "url": "https://github.com/berthelius/frihet-mcp",
+  "url": "https://github.com/Frihet-io/frihet-mcp",
   "runtime": "node",
   "license": "MIT",
   "env": {


### PR DESCRIPTION
## Summary

Adds **Frihet** (`@frihet/mcp-server`) to the `finance-fintech` category.

Frihet is an AI-native business management MCP server with 31 tools covering:
- Invoicing, expenses, clients, products, quotes
- Tax compliance (VeriFactu / Spain)
- Multi-currency (40 currencies), OCR, Stripe Connect, webhooks

**Details:**
- **npm:** https://www.npmjs.com/package/@frihet/mcp-server
- **GitHub:** https://github.com/Frihet-io/frihet-mcp
- **Remote endpoint:** `https://mcp.frihet.io/mcp` (Streamable HTTP, OAuth 2.0 + PKCE)
- **Local:** stdio transport with API key (`fri_*`)
- **License:** MIT
- **Docs:** https://docs.frihet.io/desarrolladores/mcp-server

The JSON entry includes both `env` (for stdio API key auth) and `remotes` (for Streamable HTTP with OAuth 2.0), following the schema documented in CONTRIBUTING.md.