### PR TITLE
Add preflight: prompt quality scoring MCP server for Claude Code

### DIFF
--- a/packages/coding-agents/preflight.json
+++ b/packages/coding-agents/preflight.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "preflight-dev",
+  "description": "24-tool MCP server for Claude Code that catches ambiguous prompts before they cost you 2-3x in wrong→fix cycles. Features 12-category prompt scoring, correction pattern learning, cross-service contract awareness, semantic session history search with LanceDB vectors, and cost estimation.",
+  "url": "https://github.com/preflight-dev/preflight",
+  "runtime": "node",
+  "license": "mit",
+  "env": {},
+  "name": "Preflight"
+}


### PR DESCRIPTION
## What

Adds [preflight](https://github.com/preflight-dev/preflight) to the coding-agents category.

## About preflight

A 24-tool MCP server for Claude Code that catches ambiguous prompts before they cost you 2-3x in wrong→fix cycles.

**Key features:**
- 12-category prompt scoring (ambiguity, scope, context, specificity, etc.)
- Correction pattern learning — remembers past mistakes and warns before repeating them
- Cross-service contract awareness (types, interfaces, routes, schemas)
- Semantic session history search via LanceDB vectors
- Cost estimation for token spend and waste

**Install:** `npx preflight-dev`

**npm:** [preflight-dev](https://www.npmjs.com/package/preflight-dev)

**Category:** coding-agents (prompt quality checking for AI coding agents)