### PR TITLE
Add Arch Tools MCP server — 61 AI tools with x402 payments

### DIFF
--- a/packages/uncategorized/arch-tools-mcp.json
+++ b/packages/uncategorized/arch-tools-mcp.json
@@ -1,0 +1,23 @@
+{
+  "type": "mcp-server",
+  "name": "Arch Tools",
+  "packageName": "arch-tools-mcp",
+  "description": "61 production AI tools — web scraping, crypto data, AI generation, sentiment analysis, OCR, TTS, and more. Pay per-call with USDC via x402 protocol or use API keys. The first API platform where AI agents pay with crypto.",
+  "url": "https://github.com/Deesmo/Arch-AI-Tools",
+  "runtime": "node",
+  "license": "MIT",
+  "logo": "https://archtools.dev/logo.png",
+  "author": "Arch Tools",
+  "env": {
+    "ARCH_TOOLS_API_KEY": {
+      "description": "API key from archtools.dev (optional — can pay with USDC via x402 instead)",
+      "required": false
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://arch-tools-mcp.onrender.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Arch Tools MCP Server

**61 production AI tools** accessible via MCP with optional x402 USDC payments.

### Remote Server
- **Streamable HTTP**: `https://arch-tools-mcp.onrender.com/mcp`
- **SSE**: `https://arch-tools-mcp.onrender.com/sse`

### Tool Categories
- **AI**: Text generation, sentiment analysis, entity extraction, summarization, OCR, TTS
- **Web**: Scraping, search, screenshots, HTML→Markdown, RSS parsing
- **Crypto**: Price data, OHLCV, market cap, fear/greed index, news
- **Utility**: QR codes, hash generation, format conversion, diff, regex generation
- **Communication**: Email, social posting, webhooks

### x402 Payment Support
All endpoints support x402 USDC payments on Base, Polygon, Avalanche, and Solana. No API key needed — agents pay per-call.

- **x402 Discovery**: https://archtools.dev/.well-known/x402
- **OpenAPI**: https://archtools.dev/openapi.json
- **x402scan**: Registered with 61/61 resources
- **Website**: https://archtools.dev