### PR TITLE
Add GoldRush MCP Server

### DIFF
--- a/packages/uncategorized/goldrush-mcp-server.json
+++ b/packages/uncategorized/goldrush-mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "GoldRush",
+  "packageName": "@covalenthq/goldrush-mcp-server",
+  "description": "Blockchain data across 100+ chains — wallet balances, token prices, transactions, DEX pairs, and more. REST API, real-time WebSocket with OHLCV price feeds, CLI, and x402 pay-per-request.",
+  "url": "https://github.com/covalenthq/goldrush-mcp-server",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "GOLDRUSH_API_KEY": {
+      "description": "API key for GoldRush API (get free key at goldrush.dev)",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
Exposes GoldRush APIs as MCP resources and tools, enabling LLMs to interact with blockchain data across 100+ chains.

- MCP Docs: https://goldrush.dev/docs/goldrush-mcp-server
- npm: @covalenthq/goldrush-mcp-server