### PR TITLE
Add Engrm MCP server

### DIFF
--- a/packages/developer-tools/engrm.json
+++ b/packages/developer-tools/engrm.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "engrm",
+  "description": "Shared memory for AI agents across devices, sessions, and coding systems, with continuity across OpenClaw, Claude Code, and Codex.",
+  "url": "https://github.com/dr12hes/engrm",
+  "runtime": "node",
+  "license": "fsl-1.1-alv2",
+  "env": {},
+  "name": "Engrm"
+}


### PR DESCRIPTION
Adds Engrm to the ToolSDK MCP registry.\n\nPackage details:\n- Name: Engrm\n- npm: engrm\n- Repo: https://github.com/dr12hes/engrm\n- Positioning: shared memory across devices, sessions, and coding systems, with continuity across OpenClaw, Claude Code, and Codex.