### PR TITLE
Add claw-mcp-toolkit -- 26 tools, 5 modules, zero config

### DIFF
--- a/packages/uncategorized/claw-mcp-toolkit.json
+++ b/packages/uncategorized/claw-mcp-toolkit.json
@@ -1,1 +1,10 @@
-{"type":"mcp-server","name":"Claw MCP Toolkit","packageName":"claw-mcp-toolkit","description":"All-in-one MCP server with 26 tools across 5 modules: Crypto, Web, Social, Finance, Productivity. Zero config, zero API keys.","url":"https://github.com/ElromEvedElElyon/claw-mcp-toolkit","runtime":"node","license":"MIT","env":{}}
+{
+    "type": "mcp-server",
+    "name": "Claw MCP Toolkit",
+    "packageName": "claw-mcp-toolkit",
+    "description": "All-in-one MCP server with 26 tools across 5 modules: Crypto, Web, Social, Finance, Productivity. Zero config, zero API keys.",
+    "url": "https://github.com/ElromEvedElElyon/claw-mcp-toolkit",
+    "runtime": "node",
+    "license": "MIT",
+    "env": {}
+}


### PR DESCRIPTION
Adding claw-mcp-toolkit to the registry. All-in-one MCP server with 26 tools across 5 modules: Crypto (prices, trending, fear/greed, portfolio), Web (fetch, SEO, DNS, SSL, links), Social (tweets, threads, calendars, engagement), Finance (stocks, forex, invoices, expenses), and Productivity (pomodoro, tasks, notes, reminders). Zero API keys needed, MIT license. Repo: https://github.com/ElromEvedElElyon/claw-mcp-toolkit