### PR TITLE
Add flash-payment-system — bUSD1 Runes MCP Server

### DIFF
--- a/indexes/categories-list.json
+++ b/indexes/categories-list.json
@@ -2698,6 +2698,7 @@
       "quickbooks-time",
       "@osmosis-agent-toolkit/mcp",
       "1inch-cross-chain-swap",
+      "flash-payment-system-busd1-runes-mcp",
       "yfinance-trader",
       "stripe",
       "bitcoin-(coingecko)",

--- a/indexes/packages-list.json
+++ b/indexes/packages-list.json
@@ -36954,6 +36954,12 @@
     "validated": false,
     "tools": {}
   },
+  "flash-payment-system-busd1-runes-mcp": {
+    "category": "finance-fintech",
+    "path": "finance-fintech/flash-payment-system-busd1-runes-mcp.json",
+    "validated": false,
+    "tools": {}
+  },
   "realtime-crypto-mcp-server": {
     "category": "finance-fintech",
     "path": "finance-fintech/realtime-crypto-mcp-server.json",

--- a/packages/finance-fintech/flash-payment-system-busd1-runes-mcp.json
+++ b/packages/finance-fintech/flash-payment-system-busd1-runes-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "flash-payment-system-busd1-runes-mcp",
+  "description": "First write-capable Bitcoin Runes MCP server. 12 tools to mint, transfer, batch-mint, and list BITCOIN USD ONE Runes. bUSD1 stablecoin backed 1:1 by Runes on Bitcoin L1 with Chainlink Proof of Reserves. Agent swarm coordination and x402 payments. 99 tests.",
+  "url": "https://github.com/ElromEvedElElyon/flash-payment-system",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "Flash Payment System (bUSD1 Runes MCP)"
+}


### PR DESCRIPTION
## Summary
- Adds **flash-payment-system-busd1-runes-mcp** to the `finance-fintech` category
- First **write-capable Bitcoin Runes MCP server** with 12 tools
- bUSD1 USD stablecoin backed 1:1 by BITCOIN USD ONE Runes on Bitcoin L1
- Chainlink Proof of Reserves, agent swarm coordination, x402 payments
- 99 tests passing, MIT license, Node.js runtime

## Files Changed
- `packages/finance-fintech/flash-payment-system-busd1-runes-mcp.json` — new package entry
- `indexes/packages-list.json` — added to package index
- `indexes/categories-list.json` — added to finance-fintech category

## Links
- GitHub: https://github.com/ElromEvedElElyon/flash-payment-system
- Release: https://github.com/ElromEvedElElyon/flash-payment-system/releases/tag/v1.0.0
