### PR TITLE
Add ContextWire — Free Search API for AI Agents

### DIFF
--- a/packages/uncategorized/contextwire.json
+++ b/packages/uncategorized/contextwire.json
@@ -1,17 +1,15 @@
 {
   "type": "mcp-server",
   "name": "ContextWire",
-  "packageName": "contextwire-mcp",
+  "packageName": "@toolsdk-remote/contextwire-mcp",
   "description": "Free search API for AI agents. 105 engines, 22 search profiles, 94.3% SimpleQA accuracy. MCP server with 5 tools: ask, search, extract, research, batch_search. 1,000 free queries/month.",
   "url": "https://github.com/keptlive/contextwire-mcp",
-  "homepage": "https://contextwire.dev",
   "runtime": "node",
   "license": "MIT",
-  "isRemote": true,
-  "remoteUrl": "https://contextwire.dev/mcp",
-  "capabilities": {
-    "tools": true,
-    "resources": false,
-    "prompts": false
-  }
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://contextwire.dev/mcp"
+    }
+  ]
 }


### PR DESCRIPTION
## New MCP Server: ContextWire

**ContextWire** is a search API built for AI agents.

- **105 search engines** (Google, Bing, DDG, Wikipedia, GitHub, arXiv, PubMed, etc.)
- **22 search profiles** (web, code, academic, news, finance, security, etc.)
- **94.3% SimpleQA accuracy**
- **5 MCP tools**: ask, search, extract, research, batch_search
- **Free tier**: 1,000 queries/month, no credit card
- **BYOK**: bring your own LLM key

### MCP Config

```json
{"mcpServers":{"contextwire":{"url":"https://contextwire.dev/mcp"}}}
```

### Links

- Website: https://contextwire.dev
- GitHub: https://github.com/keptlive/contextwire-mcp
- Docs: https://contextwire.dev/docs.html