### PR TITLE
Add ToolRouter — unified MCP gateway to 150+ tools

### DIFF
--- a/packages/uncategorized/toolrouter.json
+++ b/packages/uncategorized/toolrouter.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "ToolRouter",
-  "packageName": "toolrouter-mcp",
+  "packageName": "@toolsdk-remote/toolrouter-mcp",
   "description": "Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, and more. One API key replaces managing dozens of provider accounts.",
   "url": "https://toolrouter.com",
   "runtime": "node",


### PR DESCRIPTION
Adds ToolRouter — give your AI agent superpowers with access to 150+ tools on demand with just one account. One API key replaces managing dozens of separate provider accounts.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Remote MCP: https://api.toolrouter.com/mcp