### PR TITLE
Add GenieACS MCP server (embedded-system)

### DIFF
--- a/packages/embedded-system/genieacs-mcp.json
+++ b/packages/embedded-system/genieacs-mcp.json
@@ -1,0 +1,23 @@
+{
+  "type": "mcp-server",
+  "name": "GenieACS MCP",
+  "packageName": "genieacs-mcp",
+  "description": "A tiny bridge that exposes any GenieACS instance as an MCP server, enabling LLMs to query and manage TR-069 CPE devices (routers, ONTs) through the GenieACS NBI.",
+  "url": "https://github.com/GeiserX/genieacs-mcp",
+  "runtime": "node",
+  "license": "gpl-3.0",
+  "env": {
+    "ACS_URL": {
+      "description": "GenieACS NBI endpoint (e.g. http://localhost:7557)",
+      "required": true
+    },
+    "ACS_USER": {
+      "description": "GenieACS username for basic auth",
+      "required": false
+    },
+    "ACS_PASS": {
+      "description": "GenieACS password for basic auth",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds **GenieACS MCP** to the `embedded-system` category
- GenieACS MCP is a Go bridge that exposes any [GenieACS](https://github.com/genieacs/genieacs) TR-069 ACS instance as an MCP server
- Published on npm as [`genieacs-mcp`](https://www.npmjs.com/package/genieacs-mcp) and Docker as [`drumsergio/genieacs-mcp`](https://hub.docker.com/r/drumsergio/genieacs-mcp)
- Listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io)

## Details
| Field | Value |
|-------|-------|
| Package | `genieacs-mcp` (npm) |
| Runtime | `node` |
| License | GPL-3.0 |
| Category | `embedded-system` (IoT / CPE management) |
| Repo | https://github.com/GeiserX/genieacs-mcp |