### PR TITLE
feat: add Since Today commerce MCP servers (podcast, newsletter, recipe)

### DIFF
--- a/packages/search-data-extraction/newsletter-commerce-mcp.json
+++ b/packages/search-data-extraction/newsletter-commerce-mcp.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "newsletter-commerce-mcp",
+  "packageName": "@toolsdk-remote/newsletter-commerce-mcp",
   "name": "Newsletter Commerce MCP",
   "description": "Extracts affiliate-ready product entities from newsletter content. Identifies products, brands, categories, sponsorship context, and purchase intent with 100% F1 accuracy. Free tier: 200 calls/day. Paid: $0.01/call via x402 micropayments. OWASP-compliant, 643 tests.",
   "url": "https://github.com/teamsincetoday/newsletter-commerce-mcp",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://raw.githubusercontent.com/teamsincetoday/newsletter-commerce-mcp/master/assets/logo.png",
   "author": "Since Today",
   "env": {
     "OPENAI_API_KEY": {

--- a/packages/search-data-extraction/podcast-commerce-mcp.json
+++ b/packages/search-data-extraction/podcast-commerce-mcp.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "podcast-commerce-mcp",
+  "packageName": "@toolsdk-remote/podcast-commerce-mcp",
   "name": "Podcast Commerce MCP",
   "description": "Extracts affiliate-ready product entities from podcast transcripts. Identifies product names, brands, categories, prices, and recommendation strength with 100% F1 accuracy. Free tier: 200 calls/day. Paid: $0.01/call via x402 micropayments. OWASP-compliant, 643 tests.",
   "url": "https://github.com/teamsincetoday/podcast-commerce-mcp",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://raw.githubusercontent.com/teamsincetoday/podcast-commerce-mcp/master/assets/logo.png",
   "author": "Since Today",
   "env": {
     "OPENAI_API_KEY": {

--- a/packages/search-data-extraction/recipe-commerce-mcp.json
+++ b/packages/search-data-extraction/recipe-commerce-mcp.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "recipe-commerce-mcp",
+  "packageName": "@toolsdk-remote/recipe-commerce-mcp",
   "name": "Recipe Commerce MCP",
   "description": "Extracts affiliate-ready ingredient and product entities from recipe content. Identifies products, brands, categories, substitutes, and purchase links with 100% F1 accuracy. Free tier: 200 calls/day. Paid: $0.01/call via x402 micropayments. OWASP-compliant, 643 tests.",
   "url": "https://github.com/teamsincetoday/recipe-commerce-mcp",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://raw.githubusercontent.com/teamsincetoday/recipe-commerce-mcp/master/assets/logo.png",
   "author": "Since Today",
   "env": {
     "OPENAI_API_KEY": {


### PR DESCRIPTION
## Summary

Three production-ready MCP servers for affiliate-ready product extraction from content.

- **podcast-commerce-mcp**: Extracts products from podcast transcripts. Tools: `extract_podcast_products`, `analyze_episode_sponsors`, `compare_products_across_shows`.
- **newsletter-commerce-mcp**: Extracts products from newsletter content. Identifies sponsors, products, affiliate angles.
- **recipe-commerce-mcp**: Extracts products from recipe ingredients. Identifies cookware, ingredients, substitutes.

## Key specs

- Remote Streamable HTTP endpoints on Cloudflare Workers (free tier, no auth required)
- 100% F1 extraction accuracy (643 tests, all passing)
- OWASP MCP Security Guide compliant
- Free tier: 200 calls/day per agent, no API key required
- Paid: $0.01/call via x402 micropayments
- npm packages published at v0.1.2

## Endpoints

- `https://podcast-commerce-mcp.sincetoday.workers.dev/mcp`
- `https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp`
- `https://recipe-commerce-mcp.sincetoday.workers.dev/mcp`

Category: `search-data-extraction` — extracting structured product data from unstructured content.