### PR TITLE
Add Pumperly MCP server

### DIFF
--- a/packages/location-services/pumperly-mcp.json
+++ b/packages/location-services/pumperly-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "Pumperly MCP",
+  "packageName": "pumperly-mcp",
+  "description": "MCP server for Pumperly, enabling LLMs to query real-time fuel prices, find nearby stations, plan routes, and geocode locations across Spain.",
+  "url": "https://github.com/GeiserX/pumperly-mcp",
+  "runtime": "node",
+  "license": "gpl-3.0",
+  "env": {
+    "PUMPERLY_URL": {
+      "description": "Pumperly API base URL (defaults to https://pumperly.com)",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Pumperly MCP server to `packages/location-services/`
- Pumperly enables LLMs to query real-time fuel prices, find nearby stations, plan routes, and geocode locations across Spain
- Published on npm as `pumperly-mcp` and Docker Hub as `drumsergio/pumperly-mcp`

## Links
- Repository: https://github.com/GeiserX/pumperly-mcp
- npm: https://www.npmjs.com/package/pumperly-mcp