### PR TITLE
feat: add podcast, newsletter & recipe commerce MCP servers (content intelligence)

### DIFF
--- a/packages/search-data-extraction/newsletter-commerce-mcp.json
+++ b/packages/search-data-extraction/newsletter-commerce-mcp.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "newsletter-commerce-mcp",
+  "packageName": "@toolsdk-remote/newsletter-commerce-mcp",
   "name": "Newsletter Commerce MCP",
   "description": "Extracts affiliate-ready product entities from newsletter content. Identifies products, brands, categories, sponsorship context, and purchase intent with 100% F1 accuracy. Free tier: 200 calls/day. Paid: $0.01/call via x402 micropayments. OWASP-compliant, 643 tests.",
   "url": "https://github.com/teamsincetoday/newsletter-commerce-mcp",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://raw.githubusercontent.com/teamsincetoday/newsletter-commerce-mcp/master/assets/logo.png",
   "author": "Since Today",
   "env": {
     "OPENAI_API_KEY": {

--- a/packages/search-data-extraction/podcast-commerce-mcp.json
+++ b/packages/search-data-extraction/podcast-commerce-mcp.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "podcast-commerce-mcp",
+  "packageName": "@toolsdk-remote/podcast-commerce-mcp",
   "name": "Podcast Commerce MCP",
   "description": "Extracts affiliate-ready product entities from podcast transcripts. Identifies product names, brands, categories, prices, and recommendation strength with 100% F1 accuracy. Free tier: 200 calls/day. Paid: $0.01/call via x402 micropayments. OWASP-compliant, 643 tests.",
   "url": "https://github.com/teamsincetoday/podcast-commerce-mcp",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://raw.githubusercontent.com/teamsincetoday/podcast-commerce-mcp/master/assets/logo.png",
   "author": "Since Today",
   "env": {
     "OPENAI_API_KEY": {

--- a/packages/search-data-extraction/recipe-commerce-mcp.json
+++ b/packages/search-data-extraction/recipe-commerce-mcp.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "recipe-commerce-mcp",
+  "packageName": "@toolsdk-remote/recipe-commerce-mcp",
   "name": "Recipe Commerce MCP",
   "description": "Extracts affiliate-ready ingredient and product entities from recipe content. Identifies products, brands, categories, substitutes, and purchase links with 100% F1 accuracy. Free tier: 200 calls/day. Paid: $0.01/call via x402 micropayments. OWASP-compliant, 643 tests.",
   "url": "https://github.com/teamsincetoday/recipe-commerce-mcp",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://raw.githubusercontent.com/teamsincetoday/recipe-commerce-mcp/master/assets/logo.png",
   "author": "Since Today",
   "env": {
     "OPENAI_API_KEY": {


### PR DESCRIPTION
## Summary

Adds 3 remote MCP servers from Since Today's commerce intelligence suite to `packages/search-data-extraction/`:

- **podcast-commerce-mcp** — extracts affiliate-ready product entities from podcast transcripts. 100% F1 accuracy on brand/product NER.
- **newsletter-commerce-mcp** — extracts product mentions and sponsor scores from newsletters (Substack, Ghost, Beehiiv, email HTML).
- **recipe-commerce-mcp** — extracts ingredients + products from cooking video transcripts, builds affiliate shopping lists.

All 3 servers:
- Remote-capable via Cloudflare Workers (Streamable HTTP transport)
- x402 micropayment auth ($0.01/call) + free tier (200 calls/day)
- MIT license, 643 tests, OWASP-compliant

NPM: `podcast-commerce-mcp@0.1.2`, `newsletter-commerce-mcp@0.1.2`, `recipe-commerce-mcp@0.1.2`