### PR TITLE
Add Helium MCP server

### DIFF
--- a/packages/search-data-extraction/helium-mcp.json
+++ b/packages/search-data-extraction/helium-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Helium MCP",
-  "packageName": "helium-mcp",
+  "packageName": "@toolsdk-remote/helium-mcp",
   "description": "Real-time news with bias scoring across 5,000+ sources (15+ dimensions), AI-powered options pricing, balanced news synthesis, live market data, and meme search. 9 tools. 50 free queries, no signup needed.",
   "url": "https://github.com/connerlambden/helium-mcp",
   "runtime": "node",

--- a/packages/search-data-extraction/helium-mcp.json
+++ b/packages/search-data-extraction/helium-mcp.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Helium MCP",
+  "packageName": "helium-mcp",
+  "description": "Real-time news with bias scoring across 5,000+ sources (15+ dimensions), AI-powered options pricing, balanced news synthesis, live market data, and meme search. 9 tools. 50 free queries, no signup needed.",
+  "url": "https://github.com/connerlambden/helium-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://heliumtrades.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the registry under **search-data-extraction**.

- **Run locally:** `npx helium-mcp` (npm package `helium-mcp`)
- **Remote:** `streamable-http` at `https://heliumtrades.com/mcp`
- **Docs / landing:** https://heliumtrades.com/mcp-page/

News with bias scoring across 5,000+ sources, options pricing, balanced synthesis, market data, and meme search (9 tools; 50 free queries, no signup).

Made with [Cursor](https://cursor.com)