### PR TITLE
Add AgentGrade MCP server

### DIFF
--- a/packages/uncategorized/agentgrade.json
+++ b/packages/uncategorized/agentgrade.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "AgentGrade",
+  "packageName": "agentgrade",
+  "description": "Grade any website on AI agent readiness. Scores 80+ checks across payments, APIs, and discovery.",
+  "url": "https://agentgrade.com",
+  "runtime": "node",
+  "license": "MIT",
+  "logo": "https://agentgrade.com/favicon.png",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://agentgrade.com/mcp"
+    }
+  ]
+}

--- a/packages/uncategorized/agentgrade.json
+++ b/packages/uncategorized/agentgrade.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
   "name": "AgentGrade",
-  "packageName": "agentgrade",
+  "packageName": "@toolsdk-remote/agentgrade",
   "description": "Grade any website on AI agent readiness. Scores 80+ checks across payments, APIs, and discovery.",
   "url": "https://agentgrade.com",
   "runtime": "node",
   "license": "MIT",
-  "logo": "https://agentgrade.com/favicon.png",
   "env": {},
   "remotes": [
     {


### PR DESCRIPTION
AgentGrade scans any website for AI agent readiness. Scores 80+ checks across payment protocols, API discovery, and machine-readable metadata.

Remote MCP server at https://agentgrade.com/mcp (streamable HTTP, no auth required).

4 tools: scan_url, scan_compact, get_history, validate_x402_json.