### PR TITLE
Add Not Human Search and AI Dev Jobs MCP servers

### DIFF
--- a/packages/developer-tools/aidevboard.json
+++ b/packages/developer-tools/aidevboard.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "AI Dev Jobs",
+  "packageName": "@toolsdk-remote/aidevboard",
+  "description": "MCP server for searching AI and LLM developer job listings. Find roles across ML engineering, LLM fine-tuning, AI research, and agent development from 55+ ATS sources. Supports filtering by location, level, and category.",
+  "url": "https://aidevboard.com",
+  "runtime": "remote",
+  "license": "proprietary",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://aidevboard.com/mcp"
+    }
+  ]
+}

--- a/packages/search-data-extraction/nothumansearch.json
+++ b/packages/search-data-extraction/nothumansearch.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Not Human Search",
+  "packageName": "@toolsdk-remote/nothumansearch",
+  "description": "MCP-native search engine that indexes and verifies MCP servers via live JSON-RPC probes. Search 1000+ MCP tools by name, description, or capability. Returns ranked results with agentic scores, categories, and live endpoint verification.",
+  "url": "https://nothumansearch.ai",
+  "runtime": "remote",
+  "license": "proprietary",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Not Human Search** (`packages/search-data-extraction/nothumansearch.json`): MCP-native search engine that indexes and verifies 1000+ MCP servers via live JSON-RPC probes. Returns ranked results with agentic scores, endpoint verification, and category tagging. Remote streamable-http endpoint at `https://nothumansearch.ai/mcp`.

- **AI Dev Jobs** (`packages/developer-tools/aidevboard.json`): Job board for AI/LLM developers aggregating listings from 55+ ATS sources. Covers ML engineering, LLM fine-tuning, AI research, and agent development roles. Remote streamable-http endpoint at `https://aidevboard.com/mcp`.

Both servers are live, production remote MCP endpoints using the `streamable-http` transport matching the registry format established by other remote entries.

## Test plan

- [ ] Verify `nothumansearch.ai/mcp` responds to JSON-RPC `initialize` request
- [ ] Verify `aidevboard.com/mcp` responds to JSON-RPC `initialize` request
- [ ] JSON format matches existing remote entries (e.g., `a2abench.json`)