### PR TITLE
Add Not Human Search (Search) and AI Dev Jobs (Uncategorized) remote MCP servers

### DIFF
--- a/packages/search-data-extraction/not-human-search.json
+++ b/packages/search-data-extraction/not-human-search.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Not Human Search",
-  "packageName": "ai.nothumansearch/search",
+  "packageName": "@toolsdk-remote/ai.nothumansearch-search",
   "description": "Agent-first search engine indexing 8,000+ MCP servers and other agentically-readable sites, ranked by agentic readiness across 7 signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). 8 tools: search_agents, get_site_details, get_stats, list_categories, get_top_sites, submit_site, verify_mcp (live JSON-RPC probe), register_monitor.",
   "url": "https://github.com/unitedideas/nothumansearch",
   "runtime": "node",

--- a/packages/search-data-extraction/not-human-search.json
+++ b/packages/search-data-extraction/not-human-search.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Not Human Search",
+  "packageName": "ai.nothumansearch/search",
+  "description": "Agent-first search engine indexing 8,000+ MCP servers and other agentically-readable sites, ranked by agentic readiness across 7 signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). 8 tools: search_agents, get_site_details, get_stats, list_categories, get_top_sites, submit_site, verify_mcp (live JSON-RPC probe), register_monitor.",
+  "url": "https://github.com/unitedideas/nothumansearch",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  ]
+}

--- a/packages/uncategorized/ai-dev-jobs.json
+++ b/packages/uncategorized/ai-dev-jobs.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "AI Dev Jobs",
+  "packageName": "com.aidevboard/jobs",
+  "description": "Structured data for 8,400+ active AI/ML engineering jobs from 580 company ATS boards (Anthropic, OpenAI, Meta FAIR, DeepMind, Scale, Cohere, and 475+ more). Search by role, tags, location, workplace, salary, experience level. 4 tools: search_jobs, get_job, list_companies, get_stats. No auth required.",
+  "url": "https://aidevboard.com/docs",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://aidevboard.com/mcp"
+    }
+  ]
+}

--- a/packages/uncategorized/ai-dev-jobs.json
+++ b/packages/uncategorized/ai-dev-jobs.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "AI Dev Jobs",
-  "packageName": "com.aidevboard/jobs",
+  "packageName": "@toolsdk-remote/com.aidevboard-jobs",
   "description": "Structured data for 8,400+ active AI/ML engineering jobs from 580 company ATS boards (Anthropic, OpenAI, Meta FAIR, DeepMind, Scale, Cohere, and 475+ more). Search by role, tags, location, workplace, salary, experience level. 4 tools: search_jobs, get_job, list_companies, get_stats. No auth required.",
   "url": "https://aidevboard.com/docs",
   "runtime": "node",


### PR DESCRIPTION
Two remote MCP server submissions, both published in the official MCP registry.

**Not Human Search** → `packages/search-data-extraction/not-human-search.json`
- Agent-first search engine; 8,000+ sites indexed by agentic readiness
- 8 tools including `verify_mcp` (live JSON-RPC probe), `search_agents`, `get_top_sites`
- Official MCP registry: `ai.nothumansearch/search`
- Remote endpoint: https://nothumansearch.ai/mcp (streamable-http, no auth)

**AI Dev Jobs** → `packages/uncategorized/ai-dev-jobs.json`
- 8,400+ active AI/ML engineering jobs from 580 ATS sources
- 4 tools: `search_jobs`, `get_job`, `list_companies`, `get_stats`
- Official MCP registry: `com.aidevboard/jobs`
- Remote endpoint: https://aidevboard.com/mcp (streamable-http, no auth)

Both JSON files follow the schema in `docs/CONTRIBUTING.md`. Both are production-ready, actively maintained, and have no auth barrier.