### PR TITLE
Add spinnaker-mcp to cloud-platforms

### DIFF
--- a/packages/cloud-platforms/spinnaker-mcp.json
+++ b/packages/cloud-platforms/spinnaker-mcp.json
@@ -1,0 +1,27 @@
+{
+  "type": "mcp-server",
+  "name": "Spinnaker MCP",
+  "packageName": "spinnaker-mcp",
+  "description": "A bridge that exposes any Spinnaker instance as an MCP server via the Gate API, enabling LLMs to manage applications, pipelines, executions, and cloud infrastructure.",
+  "url": "https://github.com/GeiserX/spinnaker-mcp",
+  "runtime": "node",
+  "license": "gpl-3.0",
+  "env": {
+    "GATE_URL": {
+      "description": "Spinnaker Gate API URL (e.g. http://spin-gate:8084)",
+      "required": true
+    },
+    "GATE_TOKEN": {
+      "description": "Bearer token for Gate authentication",
+      "required": false
+    },
+    "GATE_USER": {
+      "description": "Basic auth username (alternative to token)",
+      "required": false
+    },
+    "GATE_PASS": {
+      "description": "Basic auth password",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
Adds [spinnaker-mcp](https://github.com/GeiserX/spinnaker-mcp) to the cloud-platforms category.

**spinnaker-mcp** is a Go-based MCP server that bridges any Spinnaker continuous delivery instance via the Gate API, exposing 37 tools for application management, pipeline operations, execution control, and infrastructure queries. Published on npm and Docker Hub.