### PR TITLE
Add EnigmAgent MCP server (Security category)

### DIFF
--- a/packages/security/enigmagent-mcp.json
+++ b/packages/security/enigmagent-mcp.json
@@ -5,14 +5,5 @@
   "description": "AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context.",
   "url": "https://github.com/Agnuxo1/EnigmAgent",
   "runtime": "node",
-  "license": "MIT",
-  "keywords": [
-    "security",
-    "vault",
-    "credentials",
-    "secrets",
-    "encryption",
-    "mcp",
-    "ai-agents"
-  ]
+  "license": "MIT"
 }

--- a/packages/security/enigmagent-mcp.json
+++ b/packages/security/enigmagent-mcp.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "EnigmAgent",
+  "packageName": "enigmagent-mcp",
+  "description": "AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context.",
+  "url": "https://github.com/Agnuxo1/EnigmAgent",
+  "runtime": "node",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "vault",
+    "credentials",
+    "secrets",
+    "encryption",
+    "mcp",
+    "ai-agents"
+  ]
+}


### PR DESCRIPTION
Adds EnigmAgent MCP server to the security category.

**EnigmAgent** is an AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. It resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts, logs, or LLM context.

- npm: `enigmagent-mcp`
- Runtime: node
- GitHub: https://github.com/Agnuxo1/EnigmAgent
- License: MIT