### PR TITLE
Add prompt-to-asset MCP server

### DIFF
--- a/packages/uncategorized/prompt-to-asset.json
+++ b/packages/uncategorized/prompt-to-asset.json
@@ -1,0 +1,9 @@
+{
+  "type": "mcp-server",
+  "name": "Prompt to Asset",
+  "packageName": "prompt-to-asset",
+  "description": "MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models. Three execution modes: inline SVG, external prompt, and full API generation. Zero API key required for first run via Pollinations and Stable Horde free tiers.",
+  "url": "https://github.com/MohamedAbdallah-14/prompt-to-asset",
+  "runtime": "node",
+  "license": "MIT"
+}


### PR DESCRIPTION
Add prompt-to-asset MCP server to uncategorized registry

**Tool:** Prompt to Asset
**npm package:** prompt-to-asset
**Runtime:** node
**License:** MIT

**What it does:**
MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models. Three execution modes: inline SVG, external prompt, and full API generation.

**Zero barrier to entry:** no API key required for a first run — uses Pollinations and Stable Horde free tiers by default.

**Links:**
- GitHub: https://github.com/MohamedAbdallah-14/prompt-to-asset
- Npm: https://www.npmjs.com/package/prompt-to-asset