### PR TITLE
feat: add KubeStellar Console to cloud-platforms

### DIFF
--- a/packages/cloud-platforms/kubestellar-console.json
+++ b/packages/cloud-platforms/kubestellar-console.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "kubestellar-console",
+  "description": "AI-powered multi-cluster Kubernetes management dashboard with built-in MCP server (kc-agent) for AI-assisted operations, compliance auditing, and cross-cluster resource management.",
+  "url": "https://github.com/kubestellar/console",
+  "runtime": "go",
+  "license": "Apache-2.0",
+  "env": {},
+  "name": "KubeStellar Console"
+}


### PR DESCRIPTION
## Add KubeStellar Console MCP Server

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the cloud-platforms category.

**What it is:** An AI-powered multi-cluster Kubernetes management dashboard with a built-in MCP server (kc-agent) that bridges AI coding assistants to Kubernetes clusters via kubeconfig.

**Key features:**
- Multi-cluster Kubernetes management dashboard
- Built-in MCP server (kc-agent) for AI-assisted operations
- Supports Claude, GPT, and Gemini via MCP protocol
- Compliance auditing and cross-cluster resource management
- Apache-2.0 license, actively maintained (CNCF project)