### PR TITLE
fix: lowercase name field in enigmagent-mcp.json

### DIFF
--- a/packages/security/enigmagent-mcp.json
+++ b/packages/security/enigmagent-mcp.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "name": "EnigmAgent",
+  "name": "enigmagent-mcp",
   "packageName": "enigmagent-mcp",
   "description": "AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context.",
   "url": "https://github.com/Agnuxo1/EnigmAgent",

--- a/packages/security/enigmagent-mcp.json
+++ b/packages/security/enigmagent-mcp.json
@@ -5,14 +5,5 @@
   "description": "AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context.",
   "url": "https://github.com/Agnuxo1/EnigmAgent",
   "runtime": "node",
-  "license": "MIT",
-  "keywords": [
-    "security",
-    "vault",
-    "credentials",
-    "secrets",
-    "encryption",
-    "mcp",
-    "ai-agents"
-  ]
+  "license": "MIT"
 }

--- a/packages/security/enigmagent-mcp.json
+++ b/packages/security/enigmagent-mcp.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "EnigmAgent",
+  "packageName": "enigmagent-mcp",
+  "description": "AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context.",
+  "url": "https://github.com/Agnuxo1/EnigmAgent",
+  "runtime": "node",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "vault",
+    "credentials",
+    "secrets",
+    "encryption",
+    "mcp",
+    "ai-agents"
+  ]
+}


### PR DESCRIPTION
Follow-up to #292 — fixes the `name` field to match the registry's lowercase format as requested by @mr-kelly.

**Change:** `"name": "EnigmAgent"` → `"name": "enigmagent-mcp"`

No other fields affected.