### PR TITLE
Add Memoire MCP package

### DIFF
--- a/packages/developer-tools/memoire.json
+++ b/packages/developer-tools/memoire.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "packageName": "@sarveshsea/memoire",
+  "bin": "memi",
+  "binArgs": ["mcp"],
+  "description": "MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes.",
+  "url": "https://github.com/sarveshsea/m-moire",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "Memoire"
+}


### PR DESCRIPTION
Adds Memoire as a Node-based MCP server package under developer tools. Local validation was attempted with `make validate packages/developer-tools/memoire.json`, but the temp clone could not install repo dependencies because the machine ran out of disk space during Bun dependency extraction.