### PR TITLE
Add MyCarTracks remote MCP server

### DIFF
--- a/packages/travel-transportation/mycartracks.json
+++ b/packages/travel-transportation/mycartracks.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "MyCarTracks",
+  "packageName": "mycartracks-mcp",
+  "description": "Mainly app-based GPS vehicle tracking and automatic mileage tracking with MCP access to trip, track, and vehicle data.",
+  "url": "https://mycartracks.com/resources/connect-with-ai",
+  "readme": "https://mycartracks.com/resources/connect-with-ai",
+  "runtime": "java",
+  "license": "unknown",
+  "logo": "https://mycartracks.com/images/android-chrome-512x512.png",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mycartracks.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds MyCarTracks as a remote Streamable HTTP MCP server in the Travel & Transportation category.\n\nValidation before submission:\n- Checked code, issues, and PRs for existing MyCarTracks entries. No duplicate found.\n- Verified the MCP endpoint is reachable and auth-protected at https://mycartracks.com/mcp.\n- Verified OAuth protected resource metadata at https://mycartracks.com/.well-known/oauth-protected-resource.\n- Verified README page and logo URL return HTTP 200.\n- Parsed the new JSON file successfully with Node.\n\nNote: I could not run the repository's Bun-based schema validator because Bun is not available in this environment.