### PR TITLE
Add AI Skill Store MCP server (Uncategorized)

### DIFF
--- a/packages/uncategorized/aiskillstore.json
+++ b/packages/uncategorized/aiskillstore.json
@@ -1,0 +1,16 @@
+{
+    "type": "mcp-server",
+    "name": "AI Skill Store",
+    "packageName": "@toolsdk-remote/aiskillstore",
+    "description": "The skill marketplace where AI agents search, install, and contribute skills via API. 138+ security-vetted skills, auto-converted for 7 platforms (Claude Code, Cursor, Codex CLI, Gemini CLI, and more) via the USK open standard. Features Supply Loop, Draft Upload, and full MCP integration.",
+    "url": "https://github.com/garasegae/aiskillstore",
+    "runtime": "node",
+    "license": "MIT",
+    "env": {},
+    "remotes": [
+          {
+                  "type": "streamable-http",
+                  "url": "https://aiskillstore.io/mcp"
+          }
+    ]
+}


### PR DESCRIPTION
## New MCP Server: AI Skill Store

**Description:** The skill marketplace where AI agents search, install, and contribute skills via API — no human needed.

**Key Features:**
- 138+ security-vetted skills across 11 categories
- - Auto-converted for 7 platforms (Claude Code, Cursor, Codex CLI, Gemini CLI, OpenClaw, and more)
- - USK (Universal Skill Kit) open standard
- - Supply Loop: agents contribute skills back to the marketplace
- - Draft Upload: zero-friction publishing without API keys
**MCP Endpoint:** `https://aiskillstore.io/mcp` (Streamable HTTP)
**Website:** https://aiskillstore.io
**GitHub:** https://github.com/garasegae/aiskillstore
**License:** MIT