### PR TITLE
Add Bortlesboat Bitcoin MCP listing

### DIFF
--- a/packages/finance-fintech/bortlesboat-bitcoin-mcp.json
+++ b/packages/finance-fintech/bortlesboat-bitcoin-mcp.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "bitcoin-mcp",
+  "key": "bortlesboat-bitcoin-mcp",
+  "description": "Bitcoin MCP server with 49 tools for fee intelligence, mempool analysis, blocks, transactions, mining, price, supply, and AI agent Bitcoin workflows. Works zero-config through Satoshi API, with optional self-hosting.",
+  "url": "https://github.com/Bortlesboat/bitcoin-mcp",
+  "runtime": "python",
+  "license": "MIT",
+  "env": {},
+  "name": "Bortlesboat Bitcoin MCP"
+}


### PR DESCRIPTION
## Summary

Adds the Bortlesboat `bitcoin-mcp` server as a separate finance/fintech listing.

This is distinct from the existing `AbdelStark/bitcoin-mcp` entry: this package is the Python `bitcoin-mcp` server backed by Satoshi API, with 49 Bitcoin tools for fee intelligence, mempool analysis, blocks, transactions, mining, price, supply, and agent workflows.

## Validation

- `python -m json.tool packages/finance-fintech/bortlesboat-bitcoin-mcp.json`
- `git diff --check`

I also tried `npx --no-install biome check packages/finance-fintech/bortlesboat-bitcoin-mcp.json`, but this checkout did not have the formatter package installed and npm refused to run it without installing dependencies.