### PR TITLE
feat: add Inferventis live financial data MCP

### DIFF
--- a/packages/finance-fintech/inferventis.json
+++ b/packages/finance-fintech/inferventis.json
@@ -15,7 +15,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://mcp-server-295985738387.europe-west1.run.app/mcp-pay"
+      "url": "https://mcp-server-295985738387.europe-west1.run.app/mcp-pay?src=toolsdk"
     }
   ]
 }

--- a/packages/finance-fintech/inferventis.json
+++ b/packages/finance-fintech/inferventis.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "Inferventis — Live Financial Data MCP",
+  "packageName": "@inferventis/mcp-server",
+  "description": "Live financial data MCP for AI agents: real-time FX rates, stock quotes, crypto prices (10,000+ coins via CoinGecko), Open Banking (PSD2/TrueLayer, 300+ banks), Stripe payment data, and a financial calculator. Includes semantic tool_finder for agent discovery. Pay-per-call via x402 micropayments on Base ($0.001 USDC) — no API key required.",
+  "url": "https://github.com/Bankee-ai/inferventis",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "X_API_KEY": {
+      "description": "Optional API key for the /mcp endpoint (Stripe billing). Use /mcp-pay instead for keyless x402 micropayment access.",
+      "required": false
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp-server-295985738387.europe-west1.run.app/mcp-pay"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **Inferventis** to the `finance-fintech` category.

**Server:** `https://mcp-server-295985738387.europe-west1.run.app/mcp-pay`
**Transport:** Streamable HTTP (remote, no install required)

### What it provides (18 tools)
- Real-time FX rates (150+ currency pairs via Open Exchange Rates)
- Stock quotes (Yahoo Finance)
- Crypto prices — 10,000+ coins via CoinGecko
- Open Banking / PSD2 account data (TrueLayer, 300+ banks across UK/EU)
- Stripe payment analytics
- Financial calculator (compound interest, currency conversion, portfolio P&L)
- `tool_finder` — semantic tool discovery for agent routing

### Payment model
Pay-per-call via **x402 micropayments on Base** ($0.001 USDC). No API key required on the `/mcp-pay` endpoint.

### Verification
```bash
curl -s -X POST https://mcp-server-295985738387.europe-west1.run.app/mcp-pay \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | jq '.result.tools | length'
# → 18
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)