### PR TITLE
Add MyCarTracks remote MCP server

### DIFF
--- a/packages/travel-transportation/mycartracks.json
+++ b/packages/travel-transportation/mycartracks.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "MyCarTracks",
+  "packageName": "mycartracks-mcp",
+  "description": "Mainly app-based GPS vehicle tracking and automatic mileage tracking with MCP access to trip, track, and vehicle data.",
+  "url": "https://mycartracks.com/resources/connect-with-ai",
+  "readme": "https://mycartracks.com/resources/connect-with-ai",
+  "runtime": "java",
+  "license": "unknown",
+  "logo": "https://mycartracks.com/images/android-chrome-512x512.png",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mycartracks.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a MyCarTracks remote MCP server package descriptor under travel transportation.
- Includes the hosted Streamable HTTP endpoint with OAuth authentication metadata.

## Validation
- Confirmed `https://mycartracks.com/resources/connect-with-ai` returns HTTP 200.
- Confirmed logo URL returns HTTP 200.
- Confirmed `https://mycartracks.com/mcp` returns HTTP 401 for unauthenticated requests, consistent with an authenticated MCP endpoint.