### PR TITLE
feat: add Not Human Search MCP server

### DIFF
--- a/packages/uncategorized/nothumansearch.json
+++ b/packages/uncategorized/nothumansearch.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Not Human Search",
+  "packageName": "@toolsdk-remote/ai.nothumansearch-search",
+  "description": "MCP-first search engine that live-probes 1,700+ agent-ready sites for real agentic readiness. Tools: search (filtered by score/category/tags), verify_mcp (live JSON-RPC endpoint test). No auth required.",
+  "url": "https://nothumansearch.ai",
+  "runtime": "other",
+  "license": "proprietary",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `packages/uncategorized/nothumansearch.json` for the Not Human Search MCP server.

**What it does**: MCP-first search engine that live-probes 1,700+ agent-ready sites for real agentic readiness. Unlike static directories, it runs live JSON-RPC verification on each indexed site before ranking.

**Tools exposed**:
- `search` — filtered search by score, category, tags. Returns site URL, score, grade, signals.
- `verify_mcp` — live JSON-RPC probe of any MCP endpoint URL. Returns real-time tool count and server health.

**Install**:
```bash
claude mcp add nothumansearch https://nothumansearch.ai/mcp
```

**Registry listing**: `ai.nothumansearch/search` (official MCP registry). No auth required.