### PR TITLE
feat: add AI Dev Board MCP server

### DIFF
--- a/packages/uncategorized/aidevboard.json
+++ b/packages/uncategorized/aidevboard.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "AI Dev Board",
+  "packageName": "@toolsdk-remote/com.aidevboard-jobs",
+  "description": "AI/ML jobs board with 8,000+ live listings. Tools: search_jobs (full-text + filters), get_job, list_categories. REST API + MCP server for agent-driven job discovery. No auth required.",
+  "url": "https://aidevboard.com",
+  "runtime": "other",
+  "license": "proprietary",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://aidevboard.com/mcp"
+    }
+  ]
+}

--- a/packages/uncategorized/nothumansearch.json
+++ b/packages/uncategorized/nothumansearch.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Not Human Search",
+  "packageName": "@toolsdk-remote/ai.nothumansearch-search",
+  "description": "MCP-first search engine that live-probes 1,700+ agent-ready sites for real agentic readiness. Tools: search (filtered by score/category/tags), verify_mcp (live JSON-RPC endpoint test). No auth required.",
+  "url": "https://nothumansearch.ai",
+  "runtime": "other",
+  "license": "proprietary",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds AI Dev Board to the uncategorized packages.

AI Dev Board is an AI/ML jobs board with 8,000+ live listings, a public REST API (OpenAPI at /openapi.yaml), and a remote MCP server at `https://aidevboard.com/mcp` (streamable-http). Tools: `search_jobs`, `get_job`, `list_categories`. No auth required.

- URL: https://aidevboard.com
- MCP: https://aidevboard.com/mcp
- OpenAPI: https://aidevboard.com/openapi.yaml