### PR TITLE
Update Xquik ToolSDK registry metadata

### DIFF
--- a/packages/search-data-extraction/xquik.json
+++ b/packages/search-data-extraction/xquik.json
@@ -2,14 +2,20 @@
   "type": "mcp-server",
   "packageName": "xquik",
   "name": "Xquik X/Twitter Data Platform",
-  "description": "X/Twitter data platform — MCP server, 76 REST API endpoints, 20 extraction tools",
+  "description": "X (Twitter) data platform for tweet search, profile tweets, follower export, media download, posting, DMs, webhooks, 100+ REST endpoints, 23 extraction types, and MCP tools.",
   "url": "https://github.com/Xquik-dev/x-twitter-scraper",
   "runtime": "node",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "env": {
     "XQUIK_API_KEY": {
-      "description": "API key for authenticating with the Xquik MCP server",
+      "description": "Xquik API key from https://dashboard.xquik.com/account",
       "required": true
     }
-  }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://xquik.com/mcp"
+    }
+  ]
 }

--- a/packages/search-data-extraction/xquik.json
+++ b/packages/search-data-extraction/xquik.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "env": {
     "XQUIK_API_KEY": {
-      "description": "Xquik API key from https://dashboard.xquik.com/account",
+      "description": "Xquik API key from https://dashboard.xquik.com/en/account",
       "required": true
     }
   },


### PR DESCRIPTION
## Summary

- Refresh the existing Xquik registry entry with current public MCP metadata.
- Update the license from UNLICENSED to MIT, matching the public repo.
- Add the hosted Streamable HTTP MCP endpoint at https://xquik.com/mcp.

## Validation

- jq . packages/search-data-extraction/xquik.json
- bun scripts/validate-package.ts packages/search-data-extraction/xquik.json --schema-only
- git diff --check

Note: full remote connection validation is not run because the Xquik MCP endpoint requires an API key.
