### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/packages/marketing/notfair.json
+++ b/packages/marketing/notfair.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "NotFair Google Ads MCP",
+  "packageName": "@toolsdk-remote/notfair-google-ads",
+  "description": "Google Ads MCP server. Connects Claude and AI agents to a Google Ads account: diagnose campaign performance (CPA, ROAS, search-term waste, quality scores), recommend optimizations (bids, budgets, negatives, ad copy), and execute approved changes via the Google Ads API with a built-in human-approval gate.",
+  "url": "https://github.com/nowork-studio/toprank",
+  "runtime": "node",
+  "license": "Proprietary",
+  "author": "nowork-studio",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://notfair.co/api/mcp/google_ads"
+    }
+  ]
+}


### PR DESCRIPTION
Adds NotFair under marketing. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. The manifest follows the schema with a remote streamable-http endpoint. Happy to adjust the format or fields if you'd prefer.