### PR TITLE
Add Packrift MCP registry entry

### DIFF
--- a/packages/uncategorized/packrift-mcp.json
+++ b/packages/uncategorized/packrift-mcp.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "Packrift MCP",
+  "packageName": "packrift-mcp",
+  "description": "Remote MCP server for Packrift's packaging-supplies catalog with product search, pricing, inventory, packaging recommendations, and checkout URLs.",
+  "url": "https://github.com/Packrift/packrift-mcp",
+  "readme": "https://github.com/Packrift/packrift-mcp#readme",
+  "runtime": "node",
+  "license": "unknown",
+  "author": "Packrift",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.packrift.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Packrift's remote MCP server as a registry entry.

Packrift MCP exposes a public packaging-supplies catalog for product search, pricing, inventory, packaging recommendations, and checkout URLs.

Source: https://github.com/Packrift/packrift-mcp
Remote endpoint: https://mcp.packrift.com/mcp

Local JSON parse passed. I could not run `make validate packages/uncategorized/packrift-mcp.json` locally because this machine does not have `bun` installed.