### PR TITLE
Add Sharpe MCP Server

### DIFF
--- a/packages/finance-fintech/sharpe-mcp.json
+++ b/packages/finance-fintech/sharpe-mcp.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "packageName": "sharpe-mcp",
+  "description": "MCP server for agent-ready crypto market intelligence, covering funding rates, futures, options, arbitrage, narratives, exchange listings, and news.",
+  "url": "https://pypi.org/project/sharpe-mcp/",
+  "readme": "https://www.sharpe.ai/docs/mcp-server",
+  "runtime": "python",
+  "license": "MIT",
+  "env": {},
+  "name": "Sharpe MCP Server",
+  "bin": "sharpe-mcp"
+}


### PR DESCRIPTION
Adds a structured registry entry for Sharpe MCP Server in the finance-fintech category.

The entry uses the published `sharpe-mcp` PyPI package, Python runtime, MIT license, and an empty `env` object because public endpoints work without a required API key. I used the PyPI URL for the package and the Sharpe docs URL as `readme` because the source repo is not public.

Validation: JSON parses cleanly and `git diff --check` passes. Full `make validate` could not complete locally because installing the registry's dependencies hit `ENOSPC` in this workspace.

Disclosure: I work on Sharpe.