### PR TITLE
Add click-to-mcp MCP server

### DIFF
--- a/packages/uncategorized/click-to-mcp.json
+++ b/packages/uncategorized/click-to-mcp.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "name": "click-to-mcp",
+  "packageName": "click-to-mcp",
+  "description": "Auto-wrap any Click or typer CLI as an MCP server without writing server code. AI agents can call existing CLI tools instantly.",
+  "url": "https://github.com/Coding-Dev-Tools/click-to-mcp",
+  "runtime": "python",
+  "license": "mit",
+  "bin": "click-to-mcp",
+  "binArgs": ["serve"],
+  "env": {}
+}


### PR DESCRIPTION
## click-to-mcp

A Python CLI tool that auto-discovers Click-based CLI tools installed in the environment and configures them as MCP servers. Makes any Click CLI instantly accessible to AI assistants like Claude, Cursor, and any MCP-compatible client.

**Key features:**
- Auto-discovers Click-based Python CLI tools
- Generates MCP server configurations automatically
- Supports stdio transport for local use
- Works with all MCP-compatible clients

**Repository:** https://github.com/Coding-Dev-Tools/click-to-mcp
**Runtime:** Python
**License:** MIT