### PR TITLE
feat: add click-to-mcp — wrap Click/Typer CLIs as MCP servers

### DIFF
--- a/packages/developer-tools/click-to-mcp.json
+++ b/packages/developer-tools/click-to-mcp.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "packageName": "click-to-mcp",
+  "description": "Auto-wrap any Click/Typer Python CLI as an MCP server for AI agent integration. Zero boilerplate — one command turns your CLI into a Model Context Protocol server.",
+  "url": "https://github.com/Coding-Dev-Tools/click-to-mcp",
+  "runtime": "python",
+  "license": "other",
+  "env": {},
+  "name": "click-to-mcp",
+  "bin": "click-to-mcp",
+  "author": "Coding-Dev-Tools"
+}


### PR DESCRIPTION
## 🤖🤖🤖 Add click-to-mcp to the registry

**Package:** click-to-mcp  
**Runtime:** Python  
**Category:** developer-tools

### What it does
Auto-wrap any [Click](https://click.palletsprojects.com/)/[Typer](https://typer.tiangolo.com/) Python CLI as an MCP server for AI agent integration. Zero boilerplate — one command turns your CLI into a Model Context Protocol server.

```bash
pip install click-to-mcp
click-to-mcp serve your-cli
```

### Links
- **GitHub:** https://github.com/Coding-Dev-Tools/click-to-mcp
- **PyPI:** https://pypi.org/project/click-to-mcp/
- **Glama listing:** https://glama.ai/mcp/servers/Coding-Dev-Tools/click-to-mcp

Already listed on: abordage/awesome-mcp (merged), awesome-mcp-servers (pending), Glama.ai, LibHunt, OpenSourceAlternative.to.