### PR TITLE
Add DPX Settlement Protocol MCP server (finance-fintech)

### DIFF
--- a/packages/finance-fintech/dpx-settlement-protocol.json
+++ b/packages/finance-fintech/dpx-settlement-protocol.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "@untitledfinancial/dpx-mcp",
+  "description": "Settlement protocol MCP server for institutional cross-border USDC transactions on Base mainnet. 14 tools covering Stability Oracle (macro, FX, ESG, climate, supply chain, earth systems), ESG scoring, FX quotes, Verification of Payee, and settlement execution. x402 pay-per-call. MiCA-aligned, GENIUS Act compatible.",
+  "url": "https://github.com/untitledfinancial/dpx-mcp",
+  "runtime": "node",
+  "license": "BSD-3-Clause",
+  "env": {},
+  "name": "DPX Settlement Protocol"
+}


### PR DESCRIPTION
Adds DPX Settlement Protocol to the `finance-fintech` category.

- **Package**: `@untitledfinancial/dpx-mcp`
- **Repo**: https://github.com/untitledfinancial/dpx-mcp
- **Runtime**: Node.js (`npx @untitledfinancial/dpx-mcp`)
- **License**: BSD-3-Clause
- **What it does**: 14-tool MCP server for institutional cross-border USDC settlement on Base mainnet. Covers Stability Oracle (10 data sources: macro, FX, ESG, climate, supply chain, earth systems), ESG scoring, FX quotes, Verification of Payee, and settlement execution.
- **Protocol**: x402 pay-per-call micropayments — no API key required.
- **Compliance**: MiCA-aligned, GENIUS Act compatible.
- **Registry**: Official MCP registry (`io.github.untitledfinancial/dpx` v2.4.2), Smithery (98/100), Glama.