### PR TITLE
feat: add CoinPaprika MCP (finance-fintech)

### DIFF
--- a/packages/finance-fintech/coinpaprika-mcp.json
+++ b/packages/finance-fintech/coinpaprika-mcp.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "name": "Coinpaprika MCP",
+  "packageName": "@coinpaprika/mcp",
+  "bin": "coinpaprika-mcp",
+  "description": "Provides CoinPaprika cryptocurrency market data: prices, tickers, OHLCV history, exchanges, coin metadata, contract address lookups, and search across 59,000+ coins and 1,100+ exchanges. Free public API, no key required for most endpoints.",
+  "url": "https://github.com/coinpaprika/coinpaprika-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {}
+}


### PR DESCRIPTION
Adds CoinPaprika MCP under `finance-fintech`. Pairs with the existing DexPaprika entry: DexPaprika covers onchain DEX data, CoinPaprika covers CEX market data (prices, tickers, OHLCV, exchanges, historical data).

Filed as the official scoped npm package `@coinpaprika/mcp` (v1.1.1). Source repo at `coinpaprika/coinpaprika-mcp`, MIT licensed. The hosted endpoint at `mcp.coinpaprika.com` is also live if users prefer that over installing.

Ran `make validate packages/finance-fintech/coinpaprika-mcp.json` before opening this PR. Schema validation passes; connection test skipped locally since I didn't install the package in the registry's working tree.