### PR TITLE
Add MartinLoop MCP package

### DIFF
--- a/packages/uncategorized/martinloop-mcp.json
+++ b/packages/uncategorized/martinloop-mcp.json
@@ -1,0 +1,28 @@
+{
+  "type": "mcp-server",
+  "runtime": "node",
+  "packageName": "@martinloop/mcp",
+  "key": "martinloop-mcp",
+  "name": "MartinLoop MCP",
+  "description": "Governed MCP server for AI coding agents with budgets, verifier gates, and inspectable runs.",
+  "readme": "https://github.com/Keesan12/martin-loop/blob/main/packages/mcp/README.md",
+  "url": "https://github.com/Keesan12/martin-loop",
+  "license": "Apache-2.0",
+  "author": "Vakeesan Mahalingam and Gobi Shanthan",
+  "bin": "martin-loop-mcp",
+  "binArgs": [],
+  "env": {
+    "MARTIN_LIVE": {
+      "description": "Set to false for stub or smoke flows when the live coding loop should be disabled.",
+      "required": false
+    },
+    "MARTIN_RUNS_DIR": {
+      "description": "Override the persistent runs directory used to store run records and verification evidence.",
+      "required": false
+    },
+    "MARTIN_MCP_WORKSPACE_ROOT": {
+      "description": "Constrain workspace-safe paths for tool calls.",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add MartinLoop MCP to the ToolSDK registry under `packages/uncategorized`
- register the published npm package `@martinloop/mcp`
- include runtime metadata and optional environment variables used for stub and persistent-run configuration

## Notes
- local validation was attempted via the repo validator script
- this workspace does not have the full dependency tree installed yet, so CI should be the source of truth for final validation