### PR TITLE
feat: add Longbridge MCP (official brokerage, 133 tools, OAuth 2.1)

### DIFF
--- a/packages/finance-fintech/longbridge-mcp.json
+++ b/packages/finance-fintech/longbridge-mcp.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "Longbridge MCP",
+  "packageName": "com.longbridge/mcp",
+  "packageVersion": "0.3.2",
+  "description": "Official Longbridge brokerage MCP — 133 tools for US/HK/CN real-time quotes, options, trading, fundamentals, IPO, alerts, DCA & portfolio management. OAuth 2.1 RFC 9728.",
+  "url": "https://github.com/longbridge/longbridge-mcp",
+  "logo": "https://raw.githubusercontent.com/longbridge/longbridge-mcp/main/docs/logo.png",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://openapi.longbridge.com/mcp",
+      "auth": {
+        "type": "oauth2",
+        "scopes": ["quote", "trade"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## New MCP Server Submission

**Server:** Longbridge MCP  
**Category:** finance-fintech  
**Package:** `com.longbridge/mcp` v0.3.2  
**GitHub:** https://github.com/longbridge/longbridge-mcp  

### Description

Official Longbridge Securities brokerage MCP server with 133 tools covering:
- Real-time quotes (US / HK / A-share / Singapore markets)
- Options chains, warrants, derivatives
- Trading (orders, positions, portfolio)
- Fundamentals, financials, earnings
- IPO calendar, corporate events, alerts
- DCA strategies, portfolio analysis

### Transport

- **Type:** Streamable HTTP (MCP spec)
- **Endpoint:** `https://openapi.longbridge.com/mcp`
- **Auth:** OAuth 2.1 (RFC 9728 — Authorization Server Metadata)

### Checklist

- [x] Added JSON file to `packages/finance-fintech/longbridge-mcp.json`
- [x] Follows the schema format in CONTRIBUTING.md
- [x] Includes `remotes` with OAuth 2.1 auth config
- [x] Official server maintained by Longbridge Securities