### PR TITLE
Add OpenRegistry MCP server (finance-fintech)

### DIFF
--- a/packages/finance-fintech/openregistry.json
+++ b/packages/finance-fintech/openregistry.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "OpenRegistry",
+  "packageName": "openregistry-mcp",
+  "description": "Connects AI agents to live data from 30 official national company registries (UK Companies House, France RNE, Germany Handelsregister, Korea OpenDART, and more) for KYB, due diligence, and ownership chain walks. Returns the registry's own response unmodified.",
+  "url": "https://github.com/sophymarine/openregistry",
+  "runtime": "node",
+  "license": "Apache-2.0",
+  "author": "sophymarine",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://openregistry.sophymarine.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds OpenRegistry, a hosted MCP server returning live data from 30 official national company registries (UK Companies House, France RNE, Germany Handelsregister, Spain BORME, Korea OpenDART, and more). For KYB, due diligence, and ownership chain walks. 27 tools, OAuth 2.1, Apache-2.0.

Hosted endpoint: https://openregistry.sophymarine.com/mcp
Repo: https://github.com/sophymarine/openregistry
Official MCP Registry: io.github.sophymarine/openregistry (v1.0.4, active)
