### PR TITLE
Add Pictify (image/GIF/PDF generation) MCP server

### DIFF
--- a/packages/art-and-culture/pictify.json
+++ b/packages/art-and-culture/pictify.json
@@ -1,0 +1,24 @@
+{
+  "type": "mcp-server",
+  "packageName": "@pictify/mcp-server",
+  "description": "Render images, animated GIFs, and PDFs from HTML/CSS, live URLs, or reusable Handlebars/FabricJS templates. Batch up to 100 personalised renders per request and A/B test image variants with built-in experiments. Hosted remote at https://mcp.pictify.io or self-host via npx @pictify/mcp-server.",
+  "url": "https://github.com/pictify-io/mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "name": "Pictify",
+  "key": "pictify",
+  "author": "pictify-io",
+  "logo": "https://pictify.io/logo.png",
+  "env": {
+    "PICTIFY_API_KEY": {
+      "description": "Pictify API key from https://pictify.io/dashboard/api-tokens",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.pictify.io"
+    }
+  ]
+}


### PR DESCRIPTION
Adds [Pictify](https://github.com/pictify-io/mcp) to `packages/art-and-culture/pictify.json`.

### What it does

Pictify is an MCP server for rendering images, animated GIFs, and PDFs from HTML/CSS, live URLs, or reusable Handlebars/FabricJS templates. Batch up to 100 personalised renders per request and A/B test image variants with built-in experiments.

### Submission details

- **Package:** `@pictify/mcp-server@1.2.1` (npm)
- **Source:** https://github.com/pictify-io/mcp
- **Hosted remote (Streamable HTTP):** `https://mcp.pictify.io`
- **License:** MIT
- **Official MCP Registry:** `io.github.pictify-io/mcp` (live)
- **Runtime:** node

### Schema

Single new file `packages/art-and-culture/pictify.json` following the registry schema (`type`, `runtime`, `packageName`, `description`, `url`, `license`, `name`, `key`, `author`, `logo`, `env`, `remotes`). No other files touched.

Happy to move to a different category — `art-and-culture` chosen as the closest peer for media generation; could also fit `marketing` or `developer-tools`.