### PR TITLE
Add Pyrimid MCP server

### DIFF
--- a/packages/finance-fintech/pyrimid.json
+++ b/packages/finance-fintech/pyrimid.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "Pyrimid",
+  "packageName": "@toolsdk-remote/pyrimid",
+  "description": "Agent-commerce MCP server for browsing x402 products, previewing USDC payment splits, and registering affiliate agents on Base.",
+  "url": "https://github.com/pyrimid-ai/pyrimid",
+  "readme": "https://github.com/pyrimid-ai/pyrimid/blob/main/README.md",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://pyrimid.ai/api/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds Pyrimid as a remote Streamable HTTP MCP server in `finance-fintech`.
- Endpoint: `https://pyrimid.ai/api/mcp`
- Repository: https://github.com/pyrimid-ai/pyrimid

## Tools exposed
- `pyrimid_browse`
- `pyrimid_buy`
- `pyrimid_preview`
- `pyrimid_categories`
- `pyrimid_register_affiliate`
- `pyrimid_vendor_stats`
- `pyrimid_commission_check`

## Verification
- Parsed `packages/finance-fintech/pyrimid.json` as JSON.
- Checked required fields from the contribution guide: `type`, `runtime`, `packageName`.
- Verified `remotes[0]` uses `streamable-http` with a valid URL.
- Confirmed the live endpoint returns the listed tools via JSON-RPC `tools/list`.
