### PR TITLE
Add Origin MCP server

### DIFF
--- a/packages/knowledge-memory/origin.json
+++ b/packages/knowledge-memory/origin.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "name": "Origin",
+  "packageName": "origin-mcp",
+  "bin": "origin-mcp",
+  "description": "Local-first memory layer for AI work. Captures decisions, handoffs, and project context, then serves source-backed recall, distilled Markdown pages, graph context, and hybrid retrieval across MCP clients.",
+  "url": "https://github.com/7xuanlu/origin",
+  "readme": "https://github.com/7xuanlu/origin#readme",
+  "runtime": "node",
+  "license": "Apache-2.0",
+  "env": {}
+}

--- a/packages/knowledge-memory/origin.json
+++ b/packages/knowledge-memory/origin.json
@@ -3,7 +3,7 @@
   "name": "Origin",
   "packageName": "origin-mcp",
   "bin": "origin-mcp",
-  "description": "Local-first memory layer for AI work. Captures decisions, handoffs, and project context, then serves source-backed recall, distilled Markdown pages, graph context, and hybrid retrieval across MCP clients.",
+  "description": "Local-first AI work memory. Captures decisions, handoffs, and project context, then serves source-backed wiki pages, graph context, and hybrid retrieval across MCP clients.",
   "url": "https://github.com/7xuanlu/origin",
   "readme": "https://github.com/7xuanlu/origin#readme",
   "runtime": "node",


### PR DESCRIPTION
## Summary
- Add Origin to the knowledge-memory MCP registry packages.
- Use the published npm package `origin-mcp` and repository metadata from the current Origin README.

## Validation
- `jq empty packages/knowledge-memory/origin.json`
- `jq -e '.type == "mcp-server" and .runtime == "node" and .packageName == "origin-mcp" and .url == "https://github.com/7xuanlu/origin" and .license == "Apache-2.0" and (.env|type == "object")' packages/knowledge-memory/origin.json`

Note: `make validate packages/knowledge-memory/origin.json` could not run locally because this environment does not have `bun` installed; the JSON follows the documented schema fields.