### PR TITLE
Add Tuning Engines MCP package

### DIFF
--- a/packages/uncategorized/tuning-engines.json
+++ b/packages/uncategorized/tuning-engines.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "Tuning Engines",
+  "packageName": "tuningengines-cli",
+  "packageVersion": "0.4.15",
+  "bin": "te",
+  "binArgs": ["mcp", "serve"],
+  "description": "Govern model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics.",
+  "url": "https://github.com/cerebrixos-org/tuning-engines-cli",
+  "readme": "https://github.com/cerebrixos-org/tuning-engines-cli#readme",
+  "logo": "https://app.tuningengines.com/icon.png",
+  "license": "MIT",
+  "author": "Ockham Labs Inc.",
+  "runtime": "node",
+  "env": {
+    "TE_API_KEY": {
+      "description": "Tenant-scoped Tuning Engines API key.",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
Thank you for maintaining ToolSDK MCP Registry. This adds the public Tuning Engines stdio MCP package.

Tuning Engines is a governed AI runtime for model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. The package is MIT licensed and published as `tuningengines-cli@0.4.14`. It runs with `te mcp serve` and requires only the tenant-scoped `TE_API_KEY` secret.

Security note: raw credential-bearing S3 validation/import/export flows are intentionally excluded from MCP and remain available through the CLI/web UI.

Validation performed locally:
- JSON parses successfully
- schema-required fields checked for `type`, `runtime`, `packageName`, `bin`, `binArgs`, and the single required `TE_API_KEY` environment variable
- public npm package and official MCP Registry metadata verified at `0.4.14`

I did not run the full registry dependency hydration locally because it installs the complete multi-thousand-package catalog graph; CI can run the repository validator against this focused JSON addition.