### PR TITLE
Add Hive Intelligence MCP package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 build:
 	bun scripts/cat-dirs.ts
   # Install the dependencies needed to run `indexing-lists.ts`
-	pnpm install --no-frozen-lockfile
+	pnpm install --ignore-scripts --no-frozen-lockfile
 	bun scripts/indexing-lists.ts
 	bun scripts/check-config.ts
   # Install dependencies based on the updated `package.json`
-	pnpm install --no-frozen-lockfile
+	pnpm install --ignore-scripts --no-frozen-lockfile
 	npx tsx scripts/test-mcp-clients.ts
-	pnpm install --no-frozen-lockfile
+	pnpm install --ignore-scripts --no-frozen-lockfile
 	pnpm prune
 	bun scripts/readme-gen.ts
 	pnpm run sort

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 build:
 	bun scripts/cat-dirs.ts
   # Install the dependencies needed to run `indexing-lists.ts`
-	pnpm install --ignore-scripts --no-frozen-lockfile
+	pnpm install --no-frozen-lockfile
 	bun scripts/indexing-lists.ts
 	bun scripts/check-config.ts
   # Install dependencies based on the updated `package.json`
-	pnpm install --ignore-scripts --no-frozen-lockfile
+	pnpm install --no-frozen-lockfile
 	npx tsx scripts/test-mcp-clients.ts
-	pnpm install --ignore-scripts --no-frozen-lockfile
+	pnpm install --no-frozen-lockfile
 	pnpm prune
 	bun scripts/readme-gen.ts
 	pnpm run sort

--- a/packages/finance-fintech/hive-intelligence.json
+++ b/packages/finance-fintech/hive-intelligence.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "packageName": "hive-intelligence",
+  "description": "Managed crypto intelligence MCP for AI agents with 369 callable tools across market data, DeFi, wallets, token risk, DEX, NFTs, Solana, infrastructure, prediction markets, and stateful monitoring.",
+  "url": "https://github.com/hive-intel/hive-sdk",
+  "readme": "https://github.com/hive-intel/hive-sdk#readme",
+  "runtime": "node",
+  "license": "UNLICENSED",
+  "env": {
+    "HIVE_API_KEY": {
+      "description": "Hive API key for live tool execution. Create a free key at https://hiveintelligence.xyz/dashboard/keys.",
+      "required": true
+    }
+  },
+  "name": "Hive Intelligence",
+  "bin": "hive"
+}

--- a/packages/finance-fintech/hive-intelligence.json
+++ b/packages/finance-fintech/hive-intelligence.json
@@ -12,6 +12,5 @@
       "required": true
     }
   },
-  "name": "Hive Intelligence",
-  "bin": "hive"
+  "name": "Hive Intelligence"
 }


### PR DESCRIPTION
## Summary
- add Hive Intelligence to `packages/finance-fintech` as a Node MCP package
- point the listing at the public `hive-sdk` repo and README
- declare `HIVE_API_KEY` as the required runtime env var for live execution

## Notes
- I did not add a `remotes` entry because this registry schema currently models OAuth remotes, while Hive hosted MCP currently uses API-key header auth. The npm stdio package is the compatible install surface here.

## Verification
- `jq . packages/finance-fintech/hive-intelligence.json`
- Node schema-shape check for required fields, URL validity, runtime, and `HIVE_API_KEY`
- `git diff --check`

I also attempted `pnpm install --ignore-scripts --frozen-lockfile` to run `scripts/validate-package.ts`, but the full registry dependency install exceeded local disk space after pulling thousands of packages.