### PR TITLE
Add Pyrimid MCP server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 build:
 	bun scripts/cat-dirs.ts
   # Install the dependencies needed to run `indexing-lists.ts`
-	pnpm install --no-frozen-lockfile
+	pnpm install --ignore-scripts --no-frozen-lockfile
 	bun scripts/indexing-lists.ts
 	bun scripts/check-config.ts
   # Install dependencies based on the updated `package.json`
-	pnpm install --no-frozen-lockfile
+	pnpm install --ignore-scripts --no-frozen-lockfile
 	npx tsx scripts/test-mcp-clients.ts
-	pnpm install --no-frozen-lockfile
+	pnpm install --ignore-scripts --no-frozen-lockfile
 	pnpm prune
 	bun scripts/readme-gen.ts
 	pnpm run sort

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 build:
 	bun scripts/cat-dirs.ts
   # Install the dependencies needed to run `indexing-lists.ts`
-	pnpm install --ignore-scripts --no-frozen-lockfile
+	pnpm install --no-frozen-lockfile
 	bun scripts/indexing-lists.ts
 	bun scripts/check-config.ts
   # Install dependencies based on the updated `package.json`
-	pnpm install --ignore-scripts --no-frozen-lockfile
+	pnpm install --no-frozen-lockfile
 	npx tsx scripts/test-mcp-clients.ts
-	pnpm install --ignore-scripts --no-frozen-lockfile
+	pnpm install --no-frozen-lockfile
 	pnpm prune
 	bun scripts/readme-gen.ts
 	pnpm run sort

--- a/packages/finance-fintech/pyrimid.json
+++ b/packages/finance-fintech/pyrimid.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "packageName": "pyrimid",
+  "description": "MCP server and x402 catalog for paid AI/API products, paid MCP tools, and agent-to-agent commerce on Base USDC.",
+  "url": "https://github.com/pyrimid-ai/pyrimid",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "Pyrimid",
+  "readme": "https://github.com/pyrimid-ai/pyrimid#readme",
+  "logo": "https://pyrimid.ai/favicon.ico",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://pyrimid.ai/api/mcp"
+    }
+  ]
+}

--- a/packages/finance-fintech/pyrimid.json
+++ b/packages/finance-fintech/pyrimid.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "pyrimid",
+  "packageName": "@toolsdk-remote/pyrimid",
   "description": "MCP server and x402 catalog for paid AI/API products, paid MCP tools, and agent-to-agent commerce on Base USDC.",
   "url": "https://github.com/pyrimid-ai/pyrimid",
   "runtime": "node",


### PR DESCRIPTION
Adds Pyrimid as a Finance & Fintech MCP server with its public Streamable HTTP endpoint.\n\nValidation:\n- JSON parsed successfully with jq\n- Schema-equivalent local check passed against the fields in src/shared/schemas/common-schema.ts\n- https://pyrimid.ai/api/mcp returned the advertised tool list\n- https://pyrimid.ai/.well-known/mcp.json advertises streamable-http at the same endpoint\n\nNote: make validate could not run locally because bun is not installed in this environment.