### PR TITLE
Add Hyper (AI marketing agent platform)

### DIFF
--- a/packages/marketing/hyper.json
+++ b/packages/marketing/hyper.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "packageName": "hyperfx-ai/marketing-skills",
+  "description": "Connects AI agents to 200+ marketing integrations and tools, covering paid ads (Google Ads, Meta, TikTok, LinkedIn, Amazon, Pinterest), SEO and analytics (GA4, Search Console, Google Tag Manager, BigQuery), social publishing, ad-library and social scrapers, and image and video generation, with every action gated behind human-in-the-loop approval.",
+  "url": "https://github.com/hyperfx-ai/marketing-skills",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "Hyper",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://hyperfx.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds **Hyper** to `packages/marketing/`. Hyper is a hosted AI agent platform for marketing: its open-source, MIT-licensed Agent Skills plus a hosted MCP connect AI agents to 200+ marketing integrations and tools across paid ads (Google Ads, Meta, TikTok, LinkedIn, Amazon, Pinterest), SEO and analytics (GA4, Search Console, Google Tag Manager, BigQuery), social, ad-library and social scrapers, and image/video generation, with every action gated behind human-in-the-loop approval.

Install: `npx skills add hyperfx-ai/marketing-skills`. Source: https://github.com/hyperfx-ai/marketing-skills (MIT). The entry includes the hosted `remotes` endpoint (https://hyperfx.ai/mcp) per the Remote MCP Servers schema. JSON validates against `common-schema.ts`. Featured by Supabase: https://supabase.com/customers/hyper