### PR TITLE
Add 5 AutomateLab MCP servers (ai-seo, seo-performance, content-distribution, citation-intelligence, n8n)

### DIFF
--- a/packages/developer-tools/automatelab-n8n-mcp.json
+++ b/packages/developer-tools/automatelab-n8n-mcp.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "@automatelab/n8n-mcp",
+  "name": "n8n MCP (AutomateLab)",
+  "description": "Nine tools for n8n workflow development: generate valid workflow JSON from natural language, scaffold custom node TypeScript skeletons, lint workflows for deprecated node types, missing typeVersion, and broken connections, and diagnose per-node execution failures. Debugging-first design with no live n8n instance required for authoring.",
+  "url": "https://github.com/AutomateLab-tech/n8n-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "AutomateLab",
+  "env": {}
+}

--- a/packages/marketing/automatelab-ai-seo-mcp.json
+++ b/packages/marketing/automatelab-ai-seo-mcp.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "@automatelab/ai-seo-mcp",
+  "name": "AI SEO MCP (AutomateLab)",
+  "description": "19 tools to audit, score, and rewrite pages for AI-citation eligibility (AEO/GEO/LLM visibility). Scores schema.org coverage, robots.txt and llms.txt health, canonical and OpenGraph setup, and AI-citation likelihood. Includes an Agentic Browsing score (llms.txt + WebMCP + a11y-tree + layout stability) and per-section answer-extractability scoring. Also ships a GitHub Action that gates PRs on a minimum AI-SEO score. Read-only, no API keys required.",
+  "url": "https://github.com/AutomateLab-tech/ai-seo-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "AutomateLab",
+  "env": {}
+}

--- a/packages/marketing/automatelab-content-distribution-mcp.json
+++ b/packages/marketing/automatelab-content-distribution-mcp.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "@ratamaha/content-distribution-mcp",
+  "name": "Content Distribution MCP (AutomateLab)",
+  "description": "8 tools to publish one piece of content to multiple channels: DEV.to, Hashnode, GitHub Discussions, Reddit, Bluesky, Medium, LinkedIn, and Twitter. Features idempotent retry, per-platform adaptation, and scheduling. No vendor lock-in — bring your own API keys.",
+  "url": "https://github.com/AutomateLab-tech/content-distribution-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "AutomateLab",
+  "env": {}
+}

--- a/packages/marketing/automatelab-seo-performance-mcp.json
+++ b/packages/marketing/automatelab-seo-performance-mcp.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "packageName": "@automatelab/seo-performance-mcp",
+  "name": "SEO Performance MCP (AutomateLab)",
+  "description": "Post-publish SEO performance MCP that unifies Google Search Console, Matomo, GA4, Clarity, and AI-citation signals per URL. Emits a per-post verdict (refresh / expand / merge / kill / double_down / hold) with reason codes. Tracks impressions, CTR, decay curves, and citation gaps across AI engines.",
+  "url": "https://github.com/AutomateLab-tech/seo-performance-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "AutomateLab",
+  "env": {
+    "GSC_CLIENT_EMAIL": {
+      "description": "Google Search Console service account email",
+      "required": true
+    },
+    "GSC_PRIVATE_KEY": {
+      "description": "Google Search Console service account private key",
+      "required": true
+    }
+  }
+}

--- a/packages/search-data-extraction/automatelab-citation-intelligence.json
+++ b/packages/search-data-extraction/automatelab-citation-intelligence.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "@automatelab/citation-intelligence",
+  "name": "Citation Intelligence MCP (AutomateLab)",
+  "description": "26 tools to query which URLs Perplexity, Claude, ChatGPT, Gemini, Google AI Overviews, and Bing cite for any query. Tracks citation rate, share of voice vs competitors, average rank, and sentiment over a query set via a turnkey report.visibility tool. Self-hosted, BYO API keys, no backend.",
+  "url": "https://github.com/AutomateLab-tech/citation-intelligence",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "AutomateLab",
+  "env": {}
+}


### PR DESCRIPTION
## Summary

Adds 5 open-source MCP servers from [AutomateLab](https://automatelab.tech), an AI automation studio. All are MIT-licensed, published on npm, and actively maintained.

### marketing/

| File | Package | Description |
|---|---|---|
| `automatelab-ai-seo-mcp.json` | `@automatelab/ai-seo-mcp` | 19 tools to audit and rewrite pages for AI-citation eligibility (AEO/GEO/LLM visibility). Scores schema.org, robots.txt, llms.txt, canonical, OpenGraph, and agentic browsability. No API keys. |
| `automatelab-seo-performance-mcp.json` | `@automatelab/seo-performance-mcp` | Unifies GSC, Matomo, GA4, Clarity, and AI-citation signals per URL → per-post verdict (refresh/expand/merge/kill/hold). |
| `automatelab-content-distribution-mcp.json` | `@ratamaha/content-distribution-mcp` | 8 tools to publish content to DEV.to, Hashnode, GitHub Discussions, Reddit, Bluesky, Medium, LinkedIn, and Twitter with idempotent retry and scheduling. |

### search-data-extraction/

| File | Package | Description |
|---|---|---|
| `automatelab-citation-intelligence.json` | `@automatelab/citation-intelligence` | 26 tools to check which URLs Perplexity, Claude, ChatGPT, Gemini, Google AI Overviews, and Bing cite for any query. BYO API keys, self-hosted. |

### developer-tools/

| File | Package | Description |
|---|---|---|
| `automatelab-n8n-mcp.json` | `@automatelab/n8n-mcp` | 9 tools for n8n workflow development: generate workflow JSON from natural language, lint for deprecated nodes and broken connections, diagnose per-node execution failures. |

## Links

- GitHub org: https://github.com/AutomateLab-tech
- npm: https://www.npmjs.com/~automatelab