### PR TITLE
Add CoderPlan LLM API Gateway

### DIFF
--- a/packages/aggregators/coderplan.json
+++ b/packages/aggregators/coderplan.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "packageName": "coderplan",
+  "description": "OpenAI-compatible LLM API gateway supporting Claude, GPT, Gemini, DeepSeek, and Grok models with pay-per-use pricing. Provides low-latency access via Hong Kong and Singapore nodes.",
+  "url": "https://github.com/coderplan-ai/coderplan",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {
+    "OPENAI_API_KEY": {
+      "description": "CoderPlan API key from https://coderplan.ai",
+      "required": true
+    },
+    "OPENAI_BASE_URL": {
+      "description": "CoderPlan API endpoint: https://api.coderplan.ai/v1",
+      "required": true
+    }
+  },
+  "name": "CoderPlan"
+}


### PR DESCRIPTION
## Summary

Adds CoderPlan as an LLM API gateway MCP server in the aggregators category.

## Details

- **CoderPlan** is an OpenAI-compatible LLM API gateway supporting Claude, GPT, Gemini, DeepSeek, and Grok models.
- Pay-per-use pricing with low-latency Hong Kong and Singapore nodes.
- Compatible with any MCP server or tool that uses the OpenAI SDK by setting `OPENAI_API_KEY` and `OPENAI_BASE_URL`.

## File

- `packages/aggregators/coderplan.json` — new entry

## Validation

- JSON syntax validated
- Schema fields match `MCPServerPackageConfigSchema` (type, runtime, packageName, env with description + required)
- Format follows existing aggregator entries (e.g., `openrouter.json`, `multi-llm-api-gateway.json`)