### PR TITLE
Add CoderPlan MCP server - OpenAI-compatible LLM API gateway

### DIFF
--- a/packages/uncategorized/coderplan-mcp.json
+++ b/packages/uncategorized/coderplan-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "CoderPlan",
+  "packageName": "@coderplan-ai/coderplan-mcp",
+  "description": "OpenAI-compatible LLM API gateway MCP server. Access Claude, GPT-4o, Gemini, and 200+ models through a unified API.",
+  "url": "https://github.com/coderplan-ai/coderplan-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "CODERPLAN_API_KEY": {
+      "description": "API key for CoderPlan LLM gateway",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
## New MCP Server: CoderPlan

Adds [CoderPlan](https://coderplan.ai) to the registry.

**CoderPlan** is an OpenAI-compatible LLM API gateway MCP server that allows AI tools (Claude Code, Cursor, VS Code, etc.) to access Claude, GPT-4o, Gemini, and 200+ models through a unified API.

- **Repository**: https://github.com/coderplan-ai/coderplan-mcp
- **Website**: https://coderplan.ai
- **Runtime**: Node.js
- **License**: MIT
- **Category**: Placed in `packages/uncategorized/` (AI will categorize)

### JSON Entry
```json
{
  "type": "mcp-server",
  "name": "CoderPlan",
  "packageName": "@coderplan-ai/coderplan-mcp",
  "description": "OpenAI-compatible LLM API gateway MCP server. Access Claude, GPT-4o, Gemini, and 200+ models through a unified API.",
  "url": "https://github.com/coderplan-ai/coderplan-mcp",
  "runtime": "node",
  "license": "MIT"
}
```