### PR TITLE
feat: add TWZRD Agent Intel to finance-fintech (Solana x402 trust scoring)

### DIFF
--- a/packages/finance-fintech/twzrd-agent-intel.json
+++ b/packages/finance-fintech/twzrd-agent-intel.json
@@ -3,7 +3,7 @@
   "name": "TWZRD Agent Intel",
   "packageName": "twzrd-agent-intel",
   "description": "Solana-native agent trust scoring and x402 micropayment verification. Free on-chain preflight checks (agent score lookup, activity scan, wallet validation) + paid signed V5 trust receipts settled on Solana in <1s via HTTP 402.",
-  "url": "https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel",
+  "url": "https://intel.twzrd.xyz",
   "runtime": "python",
   "license": "MIT",
   "env": {},

--- a/packages/finance-fintech/twzrd-agent-intel.json
+++ b/packages/finance-fintech/twzrd-agent-intel.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "TWZRD Agent Intel",
+  "packageName": "twzrd-agent-intel",
+  "description": "Solana-native agent trust scoring and x402 micropayment verification. Free on-chain preflight checks (agent score lookup, activity scan, wallet validation) + paid signed V5 trust receipts settled on Solana in <1s via HTTP 402.",
+  "url": "https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel",
+  "runtime": "python",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://intel.twzrd.xyz/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## New MCP Server: TWZRD Agent Intel

Adds TWZRD Agent Intel to the `finance-fintech` category.

### Server Details

| Field | Value |
|-------|-------|
| **Name** | TWZRD Agent Intel |
| **Category** | finance-fintech |
| **Transport** | Streamable HTTP |
| **Runtime** | Python (FastAPI) |
| **Remote URL** | `https://intel.twzrd.xyz/mcp` |
| **Auth** | None required (x402 micropayment for paid tools) |

### What It Does

Solana-native MCP server for agent trust scoring and x402 payment verification:
- **Free tools** (4): On-chain preflight checks — agent score lookup, activity scan, wallet validation
- **Paid tools** (4): Signed V5 trust receipts via HTTP 402 → Solana USDC micropayment → `twzrd.receipt.v5` token returned

Designed for agent-to-agent commerce: AI agents can verify counterparty trust before transacting.