### PR TITLE
Add ProposalCraft — MCP server for freelance proposal drafting

### DIFF
--- a/packages/marketing/proposalcraft.json
+++ b/packages/marketing/proposalcraft.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "github:jabbawocky/proposalcraft",
+  "name": "ProposalCraft",
+  "description": "MCP server for Claude Desktop that drafts client proposals in your voice. Save 2-3 past winning proposals; ProposalCraft loads them as style examples and returns a structured context block — Claude drafts the new proposal using your examples. Zero API key required, runs entirely locally.",
+  "url": "https://github.com/jabbawocky/proposalcraft",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {}
+}

--- a/packages/marketing/proposalcraft.json
+++ b/packages/marketing/proposalcraft.json
@@ -1,6 +1,7 @@
 {
   "type": "mcp-server",
-  "packageName": "github:jabbawocky/proposalcraft",
+  "packageName": "proposalcraft",
+  "key": "proposalcraft",
   "name": "ProposalCraft",
   "description": "MCP server for Claude Desktop that drafts client proposals in your voice. Save 2-3 past winning proposals; ProposalCraft loads them as style examples and returns a structured context block — Claude drafts the new proposal using your examples. Zero API key required, runs entirely locally.",
   "url": "https://github.com/jabbawocky/proposalcraft",


### PR DESCRIPTION
ProposalCraft is an open-source MCP server for Claude Desktop that drafts client proposals in the user's voice. Users save 2–3 past winning proposals; the server loads them as style examples and returns a structured context block — Claude drafts the new proposal using those examples. Zero API key required (works with the user's existing Claude Desktop subscription), MIT licensed, installs via `npx -y github:jabbawocky/proposalcraft`.

Added to `packages/marketing/` — fits the category description (business development writing / client proposals).