### PR TITLE
Add The Stall — 201 pay-per-call market data tools (x402, no API key, v4.55.0)

### DIFF
--- a/packages/finance-fintech/the-stall.json
+++ b/packages/finance-fintech/the-stall.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "The Stall",
+  "packageName": "@toolsdk-remote/the-stall",
+  "description": "172 pay-per-call market data tools (x402, USDC). Stocks, crypto, DeFi, macro, options, compliance — no API key needed, pay-as-you-go.",
+  "url": "https://github.com/thebrierfox/the-stall",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "thebrierfox",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://the-stall.intuitek.ai/mcp"
+    }
+  ]
+}
+


### PR DESCRIPTION
## The Stall — Remote x402 MCP Server

Adds [The Stall](https://github.com/thebrierfox/the-stall) — a hosted remote MCP server with **172 pay-per-call** market data capabilities via x402 protocol (USDC micropayments on Base). No API key required — agents pay per call.

### Category
`finance-fintech`

### Coverage
- **US & global equities:** stock price, OHLCV, fundamentals, analyst ratings, earnings, dividends, insider trades, SEC filings, options chain, short volume
- **Crypto & DeFi:** price feeds, DEX quotes/pools, DeFi yields, wallet screening, token security, on-chain analytics, mempool
- **Macro & alternatives:** treasury yields, FOMC tracker, economic calendar, commodities, forex rates, housing, labor market
- **Compliance & KYB:** OFAC sanctions screening (19K+ SDN entries), NPI lookup, FEC donor search, congressional trades
- **Web & research:** news sentiment, Reddit intel, GitHub repo analysis, fact-check, research paper synthesis

### Key properties
| Property | Value |
|----------|-------|
| Transport | Streamable HTTP (`/mcp`) |
| Auth | None — x402 micropayments (USDC on Base, $0.001–$1.50/call) |
| Live endpoint | `https://the-stall.intuitek.ai/mcp` |
| Capabilities | 172 |
| Version | v4.55.0 |

```json
{
  "type": "mcp-server",
  "name": "The Stall",
  "packageName": "@toolsdk-remote/the-stall",
  "description": "172 pay-per-call market data tools (x402, USDC). Stocks, crypto, DeFi, macro, options, compliance — no API key needed, pay-as-you-go.",
  "url": "https://github.com/thebrierfox/the-stall",
  "runtime": "node",
  "license": "MIT",
  "author": "thebrierfox",
  "env": {},
  "remotes": [
    {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  ]
}
```

Built by [IntuiTek¹](https://intuitek.ai)