### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP, v4.64.0)

### DIFF
--- a/packages/finance-fintech/the-stall.json
+++ b/packages/finance-fintech/the-stall.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "the-stall",
+  "description": "181-tool pay-per-call MCP server: blockchain OSINT, DeFi analytics, OFAC sanctions screening, crypto wallet risk scoring, finance data, AI image generation, weather, and more. x402 USDC micropayments on Base — no API key needed.",
+  "url": "https://github.com/thebrierfox/the-stall",
+  "runtime": "remote",
+  "license": "MIT",
+  "env": {},
+  "name": "The Stall"
+}

--- a/packages/finance-fintech/the-stall.json
+++ b/packages/finance-fintech/the-stall.json
@@ -1,10 +1,16 @@
 {
   "type": "mcp-server",
-  "packageName": "the-stall",
-  "description": "181-tool pay-per-call MCP server: blockchain OSINT, DeFi analytics, OFAC sanctions screening, crypto wallet risk scoring, finance data, AI image generation, weather, and more. x402 USDC micropayments on Base — no API key needed.",
+  "name": "The Stall",
+  "packageName": "@toolsdk-remote/the-stall",
+  "description": "210 pay-per-call AI capabilities via x402 micropayments. Stocks, options, DeFi yields, blockchain analytics, macro data, wallet risk. USDC on Base, $0.001–$1.50/call. No API key needed.",
   "url": "https://github.com/thebrierfox/the-stall",
-  "runtime": "remote",
+  "runtime": "node",
   "license": "MIT",
   "env": {},
-  "name": "The Stall"
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://the-stall.intuitek.ai/mcp"
+    }
+  ]
 }


### PR DESCRIPTION
## New MCP Server: The Stall

Adds **The Stall** to the `finance-fintech` category.

**What it is:** A remote MCP server with 210 pay-per-call tools covering blockchain OSINT, DeFi analytics, OFAC sanctions screening (19,000+ SDN entries), crypto wallet risk scoring, finance data, AI image generation, weather, and more.

**Payment:** x402 HTTP 402 micropayments — USDC on Base. No API key, no account. Agents pay per call.

**GitHub:** https://github.com/thebrierfox/the-stall  
**Endpoint:** https://the-stall.intuitek.ai/mcp  
**MCP Registry:** Published (`the-stall.intuitek.ai`)  
**Smithery:** Listed  
**Glama:** Verified  

**Why finance-fintech:** Primary use cases are DeFi protocol analysis, on-chain wallet risk scoring, OFAC compliance screening, options/stock data, and agent-to-agent commerce via x402.
