### PR TITLE
Add API Status Check MCP server to monitoring

### DIFF
--- a/packages/monitoring/apistatuscheck-mcp-server.json
+++ b/packages/monitoring/apistatuscheck-mcp-server.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "apistatuscheck-mcp-server",
+  "description": "Check real-time operational status of 114+ cloud services and APIs — AWS, GitHub, Stripe, OpenAI, Vercel, Cloudflare, and more — directly from AI assistants without leaving the chat.",
+  "url": "https://github.com/shibley/apistatuscheck-mcp-server",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "API Status Check MCP Server"
+}


### PR DESCRIPTION
## New MCP Server Submission

**Name:** API Status Check MCP Server
**Package:** `apistatuscheck-mcp-server` (npm)
**Category:** Monitoring
**GitHub:** https://github.com/shibley/apistatuscheck-mcp-server

### Description
Checks real-time operational status of 114+ cloud services and APIs directly from AI assistants — AWS, GitHub, Stripe, OpenAI, Vercel, Cloudflare, Twilio, and more. No need to leave the chat to check if a service is down.

### Why it belongs in Monitoring
- Directly queries official status pages and APIs for accurate live data
- Covers major cloud infrastructure (AWS, GCP, Azure), developer tools (GitHub, Vercel, Netlify), payment processors (Stripe, PayPal), and AI providers (OpenAI, Anthropic, Groq)
- Available on npm, works with Claude Desktop and other MCP clients