### PR TITLE
feat: add The Stall — 207 pay-per-call AI capabilities via x402

### DIFF
--- a/packages/uncategorized/the-stall-mcp.json
+++ b/packages/uncategorized/the-stall-mcp.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "The Stall",
+  "packageName": "the-stall-mcp",
+  "description": "207 pay-per-call AI capabilities via x402 micropayments — financial data, market intelligence, blockchain analytics, weather, and more. Agents pay micro-USDC per call. No API keys, no subscriptions.",
+  "url": "https://the-stall.intuitek.ai",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://the-stall.intuitek.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Superseded by #344 which has 208 caps and v4.63.0.