### PR TITLE
Add BuyWhere MCP server — SEA product search & price comparison

### DIFF
--- a/packages/uncategorized/buywhere-mcp-server.json
+++ b/packages/uncategorized/buywhere-mcp-server.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "BuyWhere",
+  "packageName": "@buywhere/mcp-server",
+  "description": "Real-time product search and price comparison for Singapore and Southeast Asia. Search 260K+ products from Lazada, Shopee, Courts, FairPrice, and other major SEA merchants. Get live prices, stock availability, and cross-merchant comparison in a single query.",
+  "url": "https://github.com/BuyWhere/buywhere-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "BUYWHERE_API_KEY": {
+      "description": "BuyWhere API key for product search access. Get a free key at https://buywhere.ai/api-keys",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.buywhere.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## BuyWhere MCP Server

Adding BuyWhere to the uncategorized packages.

**What it does:** Real-time product search and price comparison for Singapore and Southeast Asia. Covers 260K+ products from major SEA merchants (Lazada, Shopee, Courts, FairPrice).

**Key details:**
- npm: `@buywhere/mcp-server`
- Runtime: node
- Requires `BUYWHERE_API_KEY` (free at https://buywhere.ai/api-keys)
- Remote streaming HTTP endpoint: `https://mcp.buywhere.ai/mcp`
- License: MIT
- GitHub: https://github.com/BuyWhere/buywhere-mcp