### PR TITLE
Add DOS Kernel (dos-kernel) to developer-tools

### DIFF
--- a/packages/developer-tools/dos-kernel.json
+++ b/packages/developer-tools/dos-kernel.json
@@ -1,0 +1,13 @@
+{
+  "type": "mcp-server",
+  "name": "DOS Kernel",
+  "key": "dos-kernel",
+  "packageName": "dos-kernel",
+  "description": "Trust substrate for fleets of autonomous agents: verify that a claimed task actually shipped from git evidence (never from the agent's self-report), arbitrate concurrent file access with lane leases, and refuse with typed reasons from a closed vocabulary. The MCP server needs the mcp extra: pip install \"dos-kernel[mcp]\" (server binary: dos-mcp).",
+  "url": "https://github.com/anthony-chaudhary/dos-kernel",
+  "runtime": "python",
+  "license": "MIT",
+  "bin": "dos-mcp",
+  "author": "anthony-chaudhary",
+  "env": {}
+}


### PR DESCRIPTION
Adds **DOS Kernel** (PyPI [`dos-kernel`](https://pypi.org/project/dos-kernel/), MIT) to `packages/developer-tools`.

DOS is a trust substrate for fleets of autonomous agents. The MCP server exposes the kernel's syscalls as tools:

- `dos_verify` — confirm a claimed task actually shipped, from git evidence rather than the agent's self-report
- `dos_arbitrate` — decide whether two workers may run concurrently without colliding on the same files (lane leases)
- `dos_refuse_reasons` / `dos_check_reason` — structured refusals from a closed, verifiable vocabulary

Details:

- Repo: https://github.com/anthony-chaudhary/dos-kernel
- Runtime: Python (stdio transport, no API keys / no env vars required)
- The server requires the `mcp` extra — `pip install "dos-kernel[mcp]"` — and runs as `dos-mcp`
- Also published on the official MCP Registry as `io.github.anthony-chaudhary/dos-kernel`

Happy to adjust the category or any field.
