### PR TITLE
Add MuAPI — hosted MCP server for 100+ AI models

### DIFF
--- a/packages/uncategorized/muapi-mcp-server.json
+++ b/packages/uncategorized/muapi-mcp-server.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "MuAPI",
+  "packageName": "muapi-mcp-server",
+  "description": "Hosted MCP server for 100+ generative AI models \u2014 image generation (FLUX, Midjourney, GPT-4o, HiDream), video (Veo3, Kling, HunyuanVideo, Runway), audio (Suno, MMAudio), editing (lipsync, upscale, face swap, Ghibli). No local install required.",
+  "url": "https://github.com/SamurAIGPT/muapi-mcp-server",
+  "homepage": "https://muapi.ai",
+  "runtime": "node",
+  "license": "ISC",
+  "remoteEndpoint": "https://api.muapi.ai/mcp",
+  "env": {
+    "MUAPI_API_KEY": {
+      "description": "Your MuAPI API key from muapi.ai/dashboard/keys",
+      "required": true
+    }
+  }
+}

--- a/packages/uncategorized/muapi-mcp-server.json
+++ b/packages/uncategorized/muapi-mcp-server.json
@@ -4,10 +4,14 @@
   "packageName": "muapi-mcp-server",
   "description": "Hosted MCP server for 100+ generative AI models \u2014 image generation (FLUX, Midjourney, GPT-4o, HiDream), video (Veo3, Kling, HunyuanVideo, Runway), audio (Suno, MMAudio), editing (lipsync, upscale, face swap, Ghibli). No local install required.",
   "url": "https://github.com/SamurAIGPT/muapi-mcp-server",
-  "homepage": "https://muapi.ai",
   "runtime": "node",
   "license": "ISC",
-  "remoteEndpoint": "https://api.muapi.ai/mcp",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.muapi.ai/mcp"
+    }
+  ],
   "env": {
     "MUAPI_API_KEY": {
       "description": "Your MuAPI API key from muapi.ai/dashboard/keys",

--- a/packages/uncategorized/muapi-mcp-server.json
+++ b/packages/uncategorized/muapi-mcp-server.json
@@ -1,11 +1,11 @@
 {
   "type": "mcp-server",
   "name": "MuAPI",
-  "packageName": "muapi-mcp-server",
-  "description": "Hosted MCP server for 100+ generative AI models \u2014 image generation (FLUX, Midjourney, GPT-4o, HiDream), video (Veo3, Kling, HunyuanVideo, Runway), audio (Suno, MMAudio), editing (lipsync, upscale, face swap, Ghibli). No local install required.",
+  "packageName": "@toolsdk-remote/muapi-mcp-server",
+  "description": "Hosted MCP server for 100+ generative AI models — image generation (FLUX, Midjourney, GPT-4o, HiDream), video (Veo3, Kling, HunyuanVideo, Runway), audio (Suno, MMAudio), editing (lipsync, upscale, face swap, Ghibli). No local install required.",
   "url": "https://github.com/SamurAIGPT/muapi-mcp-server",
   "runtime": "node",
-  "license": "ISC",
+  "license": "MIT",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## New MCP Server: MuAPI

**Package:** `muapi-mcp-server` (npm)
**Homepage:** https://muapi.ai
**Repo:** https://github.com/SamurAIGPT/muapi-mcp-server
**Remote endpoint:** `https://api.muapi.ai/mcp`

### What it does

Hosted MCP server providing access to 100+ generative AI models across 19 tools:
- **Image generation:** FLUX, Midjourney, GPT-4o, HiDream, Reve, SeedDream, Wan2.1
- **Video generation:** Veo3, Kling, HunyuanVideo, Runway, Pixverse, MiniMax, SeedDance
- **Audio:** Suno music creation, MMAudio sound effects
- **Editing:** lipsync, clipping, upscale, background removal, face swap, Ghibli style

Already on: Official MCP Registry (`io.github.Anil-matcha/muapi`), Smithery, Glama, Cline marketplace.