### PR TITLE
Add image2svg-mcp server

### DIFF
--- a/packages/uncategorized/image2svg-mcp.json
+++ b/packages/uncategorized/image2svg-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "name": "Image2SVG",
+  "packageName": "image2svg-mcp",
+  "description": "MCP server that converts raster images (PNG/JPG/WEBP/TIFF) to SVG vector format. Single tool, accepts base64 or URL input.",
+  "url": "https://github.com/botmonster/image2svg-mcp",
+  "runtime": "python",
+  "license": "Apache-2.0",
+  "env": {}
+}


### PR DESCRIPTION
Adds `image2svg-mcp` to `packages/uncategorized/` (per CONTRIBUTING; AI will categorize).

[image2svg-mcp](https://github.com/botmonster/image2svg-mcp) is an MCP server that converts raster images (PNG/JPG/WEBP/TIFF) to SVG vector format via a single tool, accepting base64 or URL input. PyPI package `image2svg-mcp` (`uvx image2svg-mcp`), Apache-2.0, published to the Official MCP Registry as `io.github.botmonster/image2svg-mcp`.

JSON validates against the `type`/`runtime`/`packageName` schema (`runtime: python`).