### PR TITLE
Add Superhighway web search MCP server

### DIFF
--- a/packages/search-data-extraction/superhighway-mcp.json
+++ b/packages/search-data-extraction/superhighway-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "packageName": "superhighway-mcp",
+  "description": "Web search API for AI agents. Provides web search, news search, image search, page scraping, and deep research tools that return clean JSON. Backed by the Superhighway API with a free API key or x402 USDC micropayments on Base.",
+  "url": "https://github.com/patwalls/superhighway",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "SUPERHIGHWAY_API_KEY": {
+      "description": "Your Superhighway API key from https://superhighway.walls.sh (free key available). Optional if using x402 micropayments.",
+      "required": false
+    }
+  },
+  "name": "Superhighway Web Search MCP"
+}

--- a/packages/search-data-extraction/superhighway-mcp.json
+++ b/packages/search-data-extraction/superhighway-mcp.json
@@ -1,14 +1,20 @@
 {
   "type": "mcp-server",
   "packageName": "superhighway-mcp",
-  "description": "Web search API for AI agents. Provides web search, news search, image search, page scraping, and deep research tools that return clean JSON. Backed by the Superhighway API with a free API key or x402 USDC micropayments on Base.",
+  "description": "MCP server providing live web search, news search, and page scraping, paid per call with USDC through x402.",
   "url": "https://github.com/patwalls/superhighway-mcp",
   "runtime": "node",
   "license": "MIT",
   "env": {
-    "SUPERHIGHWAY_API_KEY": {
-      "description": "Your Superhighway API key from https://superhighway.walls.sh (free key available). Optional if using x402 micropayments.",
-      "required": false
+    "AGENT_PRIVATE_KEY": {
+      "description": "Private key for a low-balance wallet funded with USDC on the selected Base network",
+      "required": true,
+      "secret": true
+    },
+    "X402_NETWORK": {
+      "description": "x402 payment network",
+      "required": false,
+      "default": "base"
     }
   },
   "name": "Superhighway Web Search MCP"

--- a/packages/search-data-extraction/superhighway-mcp.json
+++ b/packages/search-data-extraction/superhighway-mcp.json
@@ -2,7 +2,7 @@
   "type": "mcp-server",
   "packageName": "superhighway-mcp",
   "description": "Web search API for AI agents. Provides web search, news search, image search, page scraping, and deep research tools that return clean JSON. Backed by the Superhighway API with a free API key or x402 USDC micropayments on Base.",
-  "url": "https://github.com/patwalls/superhighway",
+  "url": "https://github.com/patwalls/superhighway-mcp",
   "runtime": "node",
   "license": "MIT",
   "env": {


### PR DESCRIPTION
## Add Superhighway Web Search MCP

Adds [Superhighway](https://superhighway.walls.sh) to the `search-data-extraction` category.

Superhighway is a web search API for AI agents. The MCP server (`npx -y superhighway-mcp`, published on npm) exposes 5 tools:
- `web_search` — web search
- `news_search` — news search
- `image_search` — image search
- `scrape_page` — fetch and clean a page to markdown/JSON
- `research` — multi-source deep research

Results come back as clean JSON. Auth is a free API key or x402 USDC micropayments on Base. New JSON package file follows the schema in `docs/CONTRIBUTING.md` and validates as JSON.

- npm: https://www.npmjs.com/package/superhighway-mcp
- Repo: https://github.com/patwalls/superhighway