### PR TITLE
feat: add Grafema MCP server — semantic code graph for AI agents

### DIFF
--- a/packages/developer-tools/grafema.json
+++ b/packages/developer-tools/grafema.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "name": "Grafema",
+  "packageName": "grafema",
+  "bin": "grafema-mcp",
+  "binArgs": ["--project", "."],
+  "description": "Semantic code graph MCP server for AI coding agents. Indexes your codebase into a typed graph (functions/types/modules as nodes; CALLS/IMPORTS/DATAFLOW/EFFECTS as typed edges) and exposes 40+ tools for call-chain tracing, data-flow analysis, semantic search, and invariant checking — so agents navigate code structure instead of reading files line by line.",
+  "url": "https://github.com/Disentinel/grafema",
+  "runtime": "node",
+  "license": "FSL-1.1-Apache-2.0",
+  "env": {}
+}


### PR DESCRIPTION
## What

Adds [Grafema](https://github.com/Disentinel/grafema) to the `developer-tools` category.

## About Grafema

Grafema is a semantic code graph MCP server for AI coding agents. It indexes a codebase into a typed, queryable graph and exposes 40+ MCP tools so agents can navigate code structure instead of reading files line by line.

**Key capabilities:**
- `analyze_project` — index a codebase into a typed graph (functions/types/modules as nodes; CALLS/IMPORTS/DATAFLOW/EFFECTS as edges)
- `trace_calls` / `trace_dataflow` — trace call chains and data flow across files
- `find_nodes` / `semantic_search` — find code by name, type, or semantic similarity
- `check_invariant` — verify architectural constraints across the graph

**Install & use:**
```bash
npm install -g grafema
grafema-mcp --project /path/to/project
```

- **npm**: `npm install -g grafema`
- **Transport**: stdio
- **License**: FSL-1.1-Apache-2.0
- **Platform**: macOS (arm64/x64), Linux (arm64/x64)
- **Tools**: 40+

## Checklist

- [x] JSON file placed in correct category (`developer-tools`)
- [x] Required fields: `type`, `packageName`, `runtime` filled
- [x] `env: {}` (no environment variables required)
- [x] GitHub URL provided
- [x] License specified