### PR TITLE
Add GetXAPI MCP server (Twitter/X tools, remote HTTP transport)

### DIFF
--- a/packages/uncategorized/getxapi-mcp.json
+++ b/packages/uncategorized/getxapi-mcp.json
@@ -1,0 +1,24 @@
+{
+  "type": "mcp-server",
+  "name": "GetXAPI MCP",
+  "packageName": "@getxapi/mcp",
+  "packageVersion": "0.1.1",
+  "bin": "getxapi-mcp",
+  "description": "X/Twitter MCP server with tools for tweet search, user profile lookup, follower lists, and tweet-by-id retrieval. Streamable HTTP transport with Bearer token authentication.",
+  "url": "https://github.com/getxapi/getxapi-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "GetXAPI",
+  "env": {
+    "GETXAPI_API_KEY": {
+      "description": "Bearer token for GetXAPI API access",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.getxapi.com/mcp"
+    }
+  ]
+}

--- a/packages/uncategorized/getxapi-mcp.json
+++ b/packages/uncategorized/getxapi-mcp.json
@@ -4,14 +4,14 @@
   "packageName": "@getxapi/mcp",
   "packageVersion": "0.1.1",
   "bin": "getxapi-mcp",
-  "description": "X/Twitter MCP server with tools for tweet search, user profile lookup, follower lists, and tweet-by-id retrieval. Streamable HTTP transport with Bearer token authentication.",
+  "description": "X/Twitter MCP server with tools for tweet search, user profile lookup, follower lists, and tweet-by-id retrieval.",
   "url": "https://github.com/getxapi/getxapi-mcp",
   "runtime": "node",
   "license": "MIT",
   "author": "GetXAPI",
   "env": {
-    "GETXAPI_API_KEY": {
-      "description": "Bearer token for GetXAPI API access",
+    "GETXAPI_KEY": {
+      "description": "GetXAPI API key from https://www.getxapi.com",
       "required": true
     }
   }

--- a/packages/uncategorized/getxapi-mcp.json
+++ b/packages/uncategorized/getxapi-mcp.json
@@ -14,11 +14,5 @@
       "description": "Bearer token for GetXAPI API access",
       "required": true
     }
-  },
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://api.getxapi.com/mcp"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Adds GetXAPI MCP server to `packages/uncategorized/`.

## Server details

- **Package:** `@getxapi/mcp` v0.1.1 (published on npm)
- **Source:** https://github.com/getxapi/getxapi-mcp
- **License:** MIT
- **Runtime:** Node.js
- **Transport:** Streamable HTTP (`https://api.getxapi.com/mcp`) with Bearer token authentication
- **Tools:**
  - `search_tweets` — search X/Twitter posts by query/filter
  - `get_user_profile` — fetch profile for a given username
  - `get_user_followers` — fetch follower lists
  - `get_tweet_by_id` — retrieve tweet by ID

## Recent merges in sibling projects

- DataWhisker/x-mcp-server#9
- GenAIwithMS/twitter-mcp#3
- hridaydutta123/awesome-twitter-tools#37
- Astrosp/Awesome-OSINT-List#128
- public-apis/public-apis#6194

Happy to move to a more specific category if you prefer (e.g., `social-media` or `messaging`).
