### PR TITLE
Add ProposalCraft — MCP server for freelance proposal drafting

### DIFF
--- a/packages/marketing/proposalcraft.json
+++ b/packages/marketing/proposalcraft.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "github:jabbawocky/proposalcraft",
+  "name": "ProposalCraft",
+  "description": "MCP server for Claude Desktop that drafts client proposals in your voice. Save 2-3 past winning proposals; ProposalCraft loads them as style examples and returns a structured context block — Claude drafts the new proposal using your examples. Zero API key required, runs entirely locally.",
+  "url": "https://github.com/jabbawocky/proposalcraft",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {}
+}

--- a/packages/marketing/proposalcraft.json
+++ b/packages/marketing/proposalcraft.json
@@ -1,6 +1,7 @@
 {
   "type": "mcp-server",
-  "packageName": "github:jabbawocky/proposalcraft",
+  "packageName": "proposalcraft",
+  "key": "proposalcraft",
   "name": "ProposalCraft",
   "description": "MCP server for Claude Desktop that drafts client proposals in your voice. Save 2-3 past winning proposals; ProposalCraft loads them as style examples and returns a structured context block — Claude drafts the new proposal using your examples. Zero API key required, runs entirely locally.",
   "url": "https://github.com/jabbawocky/proposalcraft",


### PR DESCRIPTION
## Summary

Adds **ProposalCraft** to the ToolSDK MCP Registry.

ProposalCraft is an open-source MCP server for Claude Desktop that drafts client proposals in your own voice. Freelancers and consultants save 2–3 of their past winning proposals, paste a new client brief, and get a ready-to-send draft — no API key, no cloud, fully local.

- **GitHub**: https://github.com/jabbawocky/proposalcraft
- **Landing page**: https://jabbawocky.github.io/proposalcraft/
- **Install**: `npx -y github:jabbawocky/proposalcraft`
- **License**: MIT
- **Pricing**: Free (5 drafts/month) · Pro $19/mo unlimited

**Tools:** `analyze_brief`, `draft_proposal`, `save_proposal`, `list_proposals`, `get_proposal`, `delete_proposal`, `check_usage`, `configure`

Also listed on Glama, mcpservers.org, and punkpeye/awesome-mcp-servers PR #8192.