### PR TITLE
Add Ignav Flights to MCP registry

### DIFF
--- a/packages/travel-transportation/ignav-flights.json
+++ b/packages/travel-transportation/ignav-flights.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "Ignav Flights",
+  "packageName": "@toolsdk-remote/com-ignav-flights",
+  "description": "Hosted Streamable HTTP MCP server for live flight prices, booking links, and airport lookup for AI agents.",
+  "url": "https://github.com/gusgordon/ignav-skill",
+  "readme": "https://github.com/gusgordon/ignav-skill/blob/main/llms-install.md",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://ignav.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adding Ignav Flights, a first-party hosted MCP server from Ignav.

Endpoint: https://ignav.com/mcp

Product docs: https://ignav.com/docs/mcp

Installation/docs: https://github.com/gusgordon/ignav-skill/blob/main/llms-install.md

Source/examples: https://github.com/gusgordon/ignav-skill

Provides live flight prices, booking links, and airport lookup for AI agents. Anonymous testing is available without signup.

Validation:
- jq parsed packages/travel-transportation/ignav-flights.json
- manual schema sanity check passed
- git diff --check passed
- make validate could not run locally because bun is not installed in this environment