### PR TITLE
Add Sequenzy MCP server

### DIFF
--- a/packages/marketing/sequenzy-mcp.json
+++ b/packages/marketing/sequenzy-mcp.json
@@ -1,0 +1,24 @@
+{
+  "type": "mcp-server",
+  "name": "Sequenzy MCP",
+  "packageName": "@sequenzy/mcp",
+  "description": "Official MCP server for Sequenzy email marketing automation: manage subscribers, lists, segments, templates, campaigns, sequences, transactional email, analytics, and AI-generated email content.",
+  "url": "https://github.com/Sequenzy/mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "SEQUENZY_API_KEY": {
+      "description": "Sequenzy API key for local stdio usage",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.sequenzy.com/v1/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}

--- a/packages/marketing/sequenzy-mcp.json
+++ b/packages/marketing/sequenzy-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Sequenzy MCP",
-  "packageName": "@sequenzy/mcp",
+  "packageName": "@toolsdk-remote/sequenzy-mcp",
   "description": "Official MCP server for Sequenzy email marketing automation: manage subscribers, lists, segments, templates, campaigns, sequences, transactional email, analytics, and AI-generated email content.",
   "url": "https://github.com/Sequenzy/mcp",
   "runtime": "node",


### PR DESCRIPTION
Adds Sequenzy's official MCP server package and hosted Streamable HTTP endpoint.\n\n- Repo: https://github.com/Sequenzy/mcp\n- Remote MCP endpoint: https://api.sequenzy.com/v1/mcp\n- npm package: @sequenzy/mcp\n\nValidation:\n- python3 -m json.tool packages/marketing/sequenzy-mcp.json