### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/packages/knowledge-memory/agentage-memory.json
+++ b/packages/knowledge-memory/agentage-memory.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "agentage Memory",
+  "packageName": "@toolsdk-remote/io-agentage-memory",
+  "description": "One memory. Every AI. Owned by you. A shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write through MCP, mirrored locally as plain .md you own and can export anytime. Tools: memory__search, memory__read, memory__write, memory__edit, memory__list, memory__delete.",
+  "url": "https://memory.agentage.io",
+  "runtime": "node",
+  "license": "unknown",
+  "logo": "https://memory.agentage.io/icon.svg",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://memory.agentage.io/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}

--- a/packages/knowledge-memory/agentage-memory.json
+++ b/packages/knowledge-memory/agentage-memory.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "name": "agentage Memory",
+  "name": "Agentage Memory",
   "packageName": "@toolsdk-remote/io-agentage-memory",
   "description": "One memory. Every AI. Owned by you. A shared memory layer for every AI - one markdown memory Claude, Cursor, and ChatGPT read and write through MCP, mirrored locally as plain .md you own and can export anytime. Tools: memory__search, memory__read, memory__write, memory__edit, memory__list, memory__delete.",
   "url": "https://memory.agentage.io",


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this list's conventions.
