### PR TITLE
Add Public Grants MCP server

### DIFF
--- a/packages/finance-fintech/public-grants.json
+++ b/packages/finance-fintech/public-grants.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Public Grants",
+  "packageName": "public-grants",
+  "description": "French public grants advisor for startups and AI agents. 21 tools for company onboarding (SIRENE registry pre-fill, auto-enrichment + customisable input), eligibility check across 49 programmes (CIR, JEI, BPI, CNC, ADEME, EIC Accelerator) with per-rule pass/fail from official legal texts, application drafting (.md/.docx export), and free strategic briefing PDF. EUR 49/dossier vs EUR 2,000-5,000 at consulting firms.",
+  "url": "https://grants.mrchief.ai",
+  "runtime": "python",
+  "author": "PyratzLabs",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://grants.mrchief.ai/mcp/"
+    }
+  ]
+}

--- a/packages/finance-fintech/public-grants.json
+++ b/packages/finance-fintech/public-grants.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Public Grants",
-  "packageName": "public-grants",
+  "packageName": "@toolsdk-remote/public-grants",
   "description": "French public grants advisor for startups and AI agents. 21 tools for company onboarding (SIRENE registry pre-fill, auto-enrichment + customisable input), eligibility check across 49 programmes (CIR, JEI, BPI, CNC, ADEME, EIC Accelerator) with per-rule pass/fail from official legal texts, application drafting (.md/.docx export), and free strategic briefing PDF. EUR 49/dossier vs EUR 2,000-5,000 at consulting firms.",
   "url": "https://grants.mrchief.ai",
   "runtime": "python",


### PR DESCRIPTION
## Add Public Grants MCP server

Adds Public Grants to the `finance-fintech` category.

Public Grants is a hosted remote MCP server that helps French startups find and apply for public funding. Traditional grant consultants charge EUR 2,000-5,000 + success fees. Public Grants: **free discovery, EUR 49/dossier**.

- 21 tools + 3 guided prompts: onboarding (SIRENE pre-fill, auto-enrichment + customisable input), discovery (49 programmes, per-rule eligibility from official legal texts), drafting (.md/.docx), strategic briefing (free PDF)
- Remote Streamable HTTP at `https://grants.mrchief.ai/mcp/`, no auth for discovery
- Written in Python (FastMCP), EU-hosted, RGPD compliant
- Source code on GitLab (private repo)
- Built by [PyratzLabs](https://pyratzlabs.com)