### PR TITLE
Add @kaitoinfra/twitterapi-io-mcp-server (TwitterAPI.io MCP Server)

### DIFF
--- a/packages/communication/twitterapi-io-mcp-server.json
+++ b/packages/communication/twitterapi-io-mcp-server.json
@@ -1,0 +1,23 @@
+{
+  "type": "mcp-server",
+  "packageName": "@kaitoinfra/twitterapi-io-mcp-server",
+  "packageVersion": "0.1.2",
+  "description": "Official Model Context Protocol (MCP) server for twitterapi.io — Twitter / X data API. Search tweets, get user profiles, followers, replies, trends — all via Claude Desktop, Cursor, or any MCP-compatible client.",
+  "url": "https://github.com/kaitoInfra/twitterapi-io-mcp-server",
+  "runtime": "node",
+  "license": "MIT",
+  "name": "TwitterAPI.io MCP Server",
+  "author": "kaitoInfra",
+  "env": {
+    "TWITTERAPI_API_KEY": {
+      "description": "API key from https://twitterapi.io (free signup, pay-per-call)",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.twitterapi.io/mcp"
+    }
+  ]
+}

--- a/packages/communication/twitterapi-io-mcp-server.json
+++ b/packages/communication/twitterapi-io-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "@kaitoinfra/twitterapi-io-mcp-server",
+  "packageName": "@toolsdk-remote/twitterapi-io-mcp-server",
   "packageVersion": "0.1.2",
   "description": "Official Model Context Protocol (MCP) server for twitterapi.io — Twitter / X data API. Search tweets, get user profiles, followers, replies, trends — all via Claude Desktop, Cursor, or any MCP-compatible client.",
   "url": "https://github.com/kaitoInfra/twitterapi-io-mcp-server",


### PR DESCRIPTION
## Summary

Adds `@kaitoinfra/twitterapi-io-mcp-server` to `packages/communication/` — the official MCP server for [twitterapi.io](https://twitterapi.io), a Twitter / X data API built for AI-agent consumption.

## Key fields

- **Package**: `@kaitoinfra/twitterapi-io-mcp-server` (npm, MIT)
- **Runtime**: node
- **Repo**: https://github.com/kaitoInfra/twitterapi-io-mcp-server
- **MCP Registry**: `io.github.kaitoInfra/twitterapi-io-mcp-server` (active since 2026-05-23)
- **Hosted endpoint** (added under `remotes`): `https://mcp.twitterapi.io/mcp` (streamable-http) — works without local install in Claude Desktop / Cursor / VS Code Copilot / any MCP-compatible client
- **Auth**: single `TWITTERAPI_API_KEY` env var (free signup tier, pay-per-call thereafter — no Twitter Developer Platform application needed)

## What can agents do with it

12 read-only tools:

- Tweet search with full operator syntax (`from:`, `to:`, `since:`, `until:`, `lang:`, `has:images`, etc.)
- User profile lookup (followers, following, public stats)
- Conversation thread expansion / reply chain reconstruction
- Real-time WebSocket streaming (filtered by keyword or user)
- Trending topics by location
- Engagement metrics on individual tweets

## Validation

- JSON validated locally against the schema described in `docs/CONTRIBUTING.md`
- Placed in `packages/communication/` alongside existing Twitter MCP entries (`enescinar-twitter-mcp.json`, `x-twitter-mcp.json`, `twitter-mcp-server.json`)

Happy to revise any fields if the maintainer prefers a different convention.
