### PR TITLE
Add BuyWhere MCP server to registry

### DIFF
--- a/packages/uncategorized/buywhere.json
+++ b/packages/uncategorized/buywhere.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "BuyWhere",
+  "packageName": "@buywhere/mcp-server",
+  "description": "Real-time product search and price-comparison MCP server. 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US. Exposes search_products, get_product, compare_products, find_best_price, get_deals, list_categories, find_similar.",
+  "url": "https://github.com/BuyWhere/buywhere-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "BUYWHERE_API_KEY": {
+      "description": "Free API key from https://api.buywhere.ai/v1/auth/register (no signup flow, 3-second registration)",
+      "required": false
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.buywhere.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Add BuyWhere MCP server to the registry

Adds `packages/uncategorized/buywhere.json` describing the BuyWhere MCP server.

### Why this fits
BuyWhere is a real-time product search and price-comparison MCP server that exposes:
- `search_products` — full-text search with merchant/region/price filters
- `get_product` — canonical product details
- `compare_products` — side-by-side cross-merchant comparison
- `find_best_price` — cheapest in-stock listing
- `get_deals`, `list_categories`, `find_similar`

### About BuyWhere MCP
- **Open source** (MIT): https://github.com/BuyWhere/buywhere-mcp
- **Remote endpoint**: `https://api.buywhere.ai/mcp` (streamable-HTTP)
- **Stdio**: `npx @buywhere/mcp-server` (auth via `BUYWHERE_API_KEY` env)
- **Coverage**: 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US
- **Free API key**, no signup (3-second `POST /v1/auth/register`)
- **MCP Registry listed**: `io.github.BuyWhere/buywhere-mcp@1.0.5`

### Schema compliance
- `type: mcp-server`
- `runtime: node`
- `license: MIT`
- `remotes: [{ type: streamable-http, url: https://api.buywhere.ai/mcp }]`
- `env` declared (BUYWHERE_API_KEY, optional)

Let me know if you'd like me to move it into a specific category folder instead of uncategorized.