### PR TITLE
Add Vestige MCP server

### DIFF
--- a/packages/knowledge-memory/vestige-mcp-server.json
+++ b/packages/knowledge-memory/vestige-mcp-server.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "packageName": "vestige-mcp-server",
+  "packageVersion": "2.1.27",
+  "description": "Local-first cognitive memory MCP server for coding agents, with SQLite storage, FSRS-style retention, hybrid retrieval, provenance/correction tools, and a dashboard.",
+  "url": "https://github.com/samvallad33/vestige",
+  "runtime": "node",
+  "license": "AGPL-3.0-only",
+  "env": {},
+  "bin": "vestige-mcp",
+  "name": "Vestige"
+}


### PR DESCRIPTION
Adds Vestige as a knowledge/memory MCP server package.

Vestige is published on npm as `vestige-mcp-server` and runs with the `vestige-mcp` binary. It provides local-first cognitive memory for coding agents with SQLite storage, FSRS-style retention, hybrid retrieval, provenance/correction tools, and a dashboard.

Checks: git diff --check; JSON/schema smoke check with Node. `make validate packages/knowledge-memory/vestige-mcp-server.json` could not run locally because `bun` is not installed in this environment.
