### PR TITLE
Add VibeKit (vibekit-mcp) to coding-agents

### DIFF
--- a/packages/coding-agents/vibekit-mcp.json
+++ b/packages/coding-agents/vibekit-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "vibekit-mcp",
+  "description": "Build, deploy, and manage hosted full-stack apps — each with a live URL and database — and chat with their per-app AI agents, from any MCP client via the VibeKit REST API.",
+  "url": "https://github.com/609NFT/vibekit-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "VibeKit"
+}


### PR DESCRIPTION
Adds vibekit-mcp (published, MIT) under packages/coding-agents/. Lets an MCP client build, deploy, and manage hosted full-stack apps (live URL + database) and chat with their per-app AI agents via the VibeKit REST API. Schema-matched (type/packageName/runtime:node/license/env). Repo 609NFT/vibekit-mcp (VibeKit.bot) — distinct from the unrelated superagent-ai/vibekit SDK.