### PR TITLE
Add hushvert MCP server

### DIFF
--- a/packages/uncategorized/hushvert-mcp.json
+++ b/packages/uncategorized/hushvert-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "Hushvert",
+  "packageName": "@hushvert/mcp",
+  "description": "MCP server that gives AI agents file-conversion tools over the hushvert hosted API: office docs to PDF, PDF to Word, video, and LLM-ready Markdown.",
+  "url": "https://github.com/hushvert/mcp",
+  "runtime": "node",
+  "license": "mit",
+  "env": {
+    "HUSHVERT_API_KEY": {
+      "description": "API key for the hushvert hosted conversion API",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
Adds an MCP server entry for **hushvert** (`@hushvert/mcp`) in `packages/uncategorized/`.

It gives AI agents file-conversion tools over the hushvert hosted API: office docs to PDF, PDF to Word, video, and LLM-ready Markdown. The JSON follows the schema (`type`, `runtime`, `packageName`, plus a required `HUSHVERT_API_KEY` env).

Disclosure: I maintain it.
