### PR TITLE
Add DocPull MCP server

### DIFF
--- a/packages/search-data-extraction/docpull.json
+++ b/packages/search-data-extraction/docpull.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "DocPull",
+  "packageName": "docpull",
+  "packageVersion": "6.0.0",
+  "description": "Local-first MCP server for turning public web sources into cited context dependencies for AI agents, RAG systems, and developer workflows.",
+  "url": "https://github.com/raintree-technology/docpull",
+  "readme": "https://github.com/raintree-technology/docpull#readme",
+  "runtime": "python",
+  "license": "MIT",
+  "author": "Raintree Technology",
+  "bin": "docpull",
+  "binArgs": ["mcp"],
+  "env": {}
+}


### PR DESCRIPTION
Adds DocPull, a PyPI-published Python stdio MCP server for turning public web/source context into cited local context packs for agents, RAG systems, and developer workflows.

Package: https://pypi.org/project/docpull/
Repository: https://github.com/raintree-technology/docpull
Install: `pip install 'docpull[mcp]'`
Run: `docpull mcp`

DocPull v6 has 17k+ PyPI downloads.