### PR TITLE
Add Publora MCP server (social media scheduling)

### DIFF
--- a/packages/marketing/publora.json
+++ b/packages/marketing/publora.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "packageName": "@publora/mcp-server",
+  "name": "Publora",
+  "description": "Schedule and publish social media posts across 10 platforms from AI agents. Create, list, update, and delete scheduled posts, request media upload URLs, list connected channels, and manage LinkedIn comments and reactions.",
+  "url": "https://github.com/publora/mcp-server",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Publora",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.publora.com"
+    }
+  ]
+}


### PR DESCRIPTION
## Add Publora to the registry

**Publora** is a social media scheduling platform. Its MCP server lets AI agents schedule and publish posts across 10 social platforms, request media upload URLs, list connected channels, and manage LinkedIn comments and reactions.

Adds `packages/marketing/publora.json`.

### Details
- **Type:** remote MCP server (Streamable HTTP) — hosted at `https://mcp.publora.com`
- **Package:** [`@publora/mcp-server`](https://www.npmjs.com/package/@publora/mcp-server) (published on npm, v1.1.0)
- **Repo:** https://github.com/publora/mcp-server
- **License:** MIT
- **Auth:** Publora API key (`sk_…`) passed as a bearer token to the remote endpoint

### Verification
- npm package resolves: `https://registry.npmjs.org/@publora/mcp-server` → 200, latest `1.1.0`
- Remote endpoint is live: `POST https://mcp.publora.com` returns `401` with `WWW-Authenticate: Bearer` (endpoint up, auth required — per the OAuth-protected-resource discovery it publishes)
- JSON validates against the `MCPServerPackageConfigSchema` Zod schema

Modeled after the existing remote entry `packages/marketing/hyper.json`.