### PR TITLE
Add supplement-advisor-mcp

### DIFF
--- a/packages/uncategorized/supplement-advisor-mcp.json
+++ b/packages/uncategorized/supplement-advisor-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "name": "Supplement Advisor MCP",
+  "packageName": "supplement-advisor-mcp",
+  "description": "Evidence-graded dietary-supplement guidance: dosing ranges, best-absorbed forms, drug-nutrient interactions, and cost-per-effective-dose. Every recommendation traces to a PubMed source.",
+  "url": "https://github.com/erinheit451/supplement-advisor-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {}
+}


### PR DESCRIPTION
Adds `supplement-advisor-mcp` to packages/uncategorized (AI can recategorize).

Evidence-graded dietary-supplement guidance: dosing ranges, best-absorbed forms, drug-nutrient interactions, and cost-per-effective-dose — every recommendation traces to a PubMed source.

- npm: https://www.npmjs.com/package/supplement-advisor-mcp (v1.1.0, published)
- Official MCP Registry: `com.verifiedsupplementdata/supplement-advisor-mcp` (active)
- Tools: recommend_supplement, compare_forms, check_interactions, get_dosage, classify_form
- License: MIT · runtime: node · no env vars required

JSON follows the common-schema (type/runtime/packageName required); validated as parseable locally.