### PR TITLE
Add ShareMyPage (remote MCP server)

### DIFF
--- a/packages/cloud-platforms/sharemypage.json
+++ b/packages/cloud-platforms/sharemypage.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "ShareMyPage",
-  "packageName": "sharemypage",
+  "packageName": "@toolsdk-remote/sharemypage",
   "description": "Host the HTML pages your AI generates and give each a shareable link, with inline comments, version history, and access control.",
   "url": "https://sharemypage.app/mcp",
   "runtime": "node",

--- a/packages/cloud-platforms/sharemypage.json
+++ b/packages/cloud-platforms/sharemypage.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "ShareMyPage",
+  "packageName": "sharemypage",
+  "description": "Host the HTML pages your AI generates and give each a shareable link, with inline comments, version history, and access control.",
+  "url": "https://sharemypage.app/mcp",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://sharemypage.app/api/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds **ShareMyPage** as a remote MCP server under `packages/cloud-platforms/`.

- Remote (streamable-http) endpoint: `https://sharemypage.app/api/mcp`, OAuth 2.1 auth (per the remote-server schema in the contributing guide).
- Lets an AI assistant host the HTML pages it generates and give each a shareable link, with inline comments, version history, and access control.
- Also listed in the official MCP Registry as `app.sharemypage/sharemypage`.

Single JSON file added, matches the remote-server example format (`remotes[]` with `auth.type: oauth2`).