### PR TITLE
Add FXMacroData MCP server

### DIFF
--- a/packages/finance-fintech/fxmacrodata.json
+++ b/packages/finance-fintech/fxmacrodata.json
@@ -1,0 +1,22 @@
+{
+  "type": "mcp-server",
+  "name": "FXMacroData MCP",
+  "packageName": "mcp-server-fxmacrodata",
+  "description": "Macroeconomic, FX, release-calendar, COT, commodities, and central-bank data for AI agents.",
+  "url": "https://github.com/fxmacrodata/mcp-server-fxmacrodata",
+  "readme": "https://github.com/fxmacrodata/mcp-server-fxmacrodata#readme",
+  "runtime": "python",
+  "license": "mit",
+  "env": {
+    "FXMD_API_KEY": {
+      "description": "Optional FXMacroData API key for protected multi-currency and premium endpoint access.",
+      "required": false
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://fxmacrodata.com/mcp"
+    }
+  ]
+}

--- a/packages/finance-fintech/fxmacrodata.json
+++ b/packages/finance-fintech/fxmacrodata.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "FXMacroData MCP",
-  "packageName": "mcp-server-fxmacrodata",
+  "packageName": "@toolsdk-remote/fxmacrodata",
   "description": "Macroeconomic, FX, release-calendar, COT, commodities, and central-bank data for AI agents.",
   "url": "https://github.com/fxmacrodata/mcp-server-fxmacrodata",
   "readme": "https://github.com/fxmacrodata/mcp-server-fxmacrodata#readme",


### PR DESCRIPTION
## Summary
- Adds FXMacroData MCP as a finance/fintech MCP server package.
- Includes the hosted Streamable HTTP MCP endpoint and optional API-key environment metadata.

## Validation
- Checked this repository for an existing `fxmacrodata` code hit before opening this submission.
- Validated the new package JSON parses locally before submission.

Disclosure: I am affiliated with FXMacroData.