### PR TITLE
Add AgentServices — x402 paid APIs for AI agents (50 services, MCP + crypto + market intelligence)

### DIFF
--- a/packages/finance-fintech/agentservices.json
+++ b/packages/finance-fintech/agentservices.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "agentservices",
+  "packageName": "@toolsdk-remote/agentservices",
   "description": "Paid APIs for AI agents via x402. 50 services covering crypto data, market intelligence, DeFi analytics, on-chain data, portfolio intelligence, and AI inference. Agents discover and pay per-call using USDC micropayments on Base.",
   "url": "https://github.com/vbkotecha/aiservices-api",
   "runtime": "node",

--- a/packages/finance-fintech/agentservices.json
+++ b/packages/finance-fintech/agentservices.json
@@ -4,7 +4,6 @@
   "description": "Paid APIs for AI agents via x402. 50 services covering crypto data, market intelligence, DeFi analytics, on-chain data, portfolio intelligence, and AI inference. Agents discover and pay per-call using USDC micropayments on Base.",
   "url": "https://github.com/vbkotecha/aiservices-api",
   "runtime": "node",
-  "license": "MIT",
   "env": {},
   "name": "AgentServices",
   "remotes": [

--- a/packages/finance-fintech/agentservices.json
+++ b/packages/finance-fintech/agentservices.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "packageName": "agentservices",
+  "description": "Paid APIs for AI agents via x402. 50 services covering crypto data, market intelligence, DeFi analytics, on-chain data, portfolio intelligence, and AI inference. Agents discover and pay per-call using USDC micropayments on Base.",
+  "url": "https://github.com/vbkotecha/aiservices-api",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "AgentServices",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://agentservices.to/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## AgentServices — Paid APIs for AI Agents

AgentServices is a remote MCP server providing 50 API services for AI agents, paid via the x402 protocol (USDC micropayments on Base).

### Categories
- **Crypto Data**: Prices, technical indicators, DeFi yields, Fear & Greed Index
- **Market Intelligence**: Sentiment analysis, trending tokens, news, social signals
- **On-Chain Analytics**: Whale movements, exchange flows, stablecoin flows, correlation matrices
- **Bundled Intelligence**: Portfolio analysis, DeFi strategy reports, market pulse, on-chain overview
- **AI Inference**: GPT model proxy with x402 payments
- **Search**: Web search optimized for agents

### Stats
- 50 total services (11 free, 39 paid)
- 36 MCP tools
- Pricing: $0.01–$0.25 per call
- Protocol: x402 v2 (USDC on Base mainnet)
- MCP endpoint: `https://agentservices.to/mcp`

### Links
- Website: [agentservices.to](https://agentservices.to)
- GitHub: [vbkotecha/aiservices-api](https://github.com/vbkotecha/aiservices-api)
- Examples: [agentservices.to/examples](https://agentservices.to/examples)
- OpenAPI spec: [agentservices.to/openapi.json](https://agentservices.to/openapi.json)
- Agent Skills: [agentservices.to/.well-known/agentskills/agentservices/SKILL.md](https://agentservices.to/.well-known/agentskills/agentservices/SKILL.md)

### Quick Test
```bash
# Free endpoint - no payment needed
curl https://agentservices.to/v1/prices?symbol=BTC

# Paid endpoint - returns 402 with x402 payment details
curl https://agentservices.to/v1/indicators/BTC
```

Fits under `finance-fintech` alongside existing entries like 1inch, A-share financial data, etc.