### PR TITLE
Add MCP servers: vindex, isocast, moltalyzer

### DIFF
--- a/packages/uncategorized/isocast-mcp.json
+++ b/packages/uncategorized/isocast-mcp.json
@@ -2,9 +2,15 @@
   "type": "mcp-server",
   "name": "Isocast",
   "packageName": "isocast-mcp",
-  "description": "Polymarket weather-market signal MCP server — temperature-bucket threshold crossings and live odds across 37 cities, for agents trading daily-temperature prediction markets. x402 pay-per-call on Base USDC, no API key.",
+  "description": "Weather-market signal MCP server for Polymarket, covering temperature-bucket threshold crossings and live odds across 37 cities. Includes free tools and optional x402 paid calls on Base USDC.",
   "url": "https://www.npmjs.com/package/isocast-mcp",
   "readme": "https://www.npmjs.com/package/isocast-mcp",
   "runtime": "node",
-  "env": {}
+  "env": {
+    "EVM_PRIVATE_KEY": {
+      "description": "Optional EVM private key used to pay for x402-protected tools on Base.",
+      "required": false,
+      "secret": true
+    }
+  }
 }

--- a/packages/uncategorized/isocast-mcp.json
+++ b/packages/uncategorized/isocast-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "name": "Isocast",
+  "packageName": "isocast-mcp",
+  "description": "Polymarket weather-market signal MCP server — temperature-bucket threshold crossings and live odds across 37 cities, for agents trading daily-temperature prediction markets. x402 pay-per-call on Base USDC, no API key.",
+  "url": "https://www.npmjs.com/package/isocast-mcp",
+  "readme": "https://www.npmjs.com/package/isocast-mcp",
+  "runtime": "node",
+  "env": {}
+}

--- a/packages/uncategorized/moltalyzer-mcp.json
+++ b/packages/uncategorized/moltalyzer-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "name": "Moltalyzer",
+  "packageName": "moltalyzer-mcp",
+  "description": "Polymarket and AI-agent-community intelligence MCP server — order-book microstructure, whale-trader calibration, and market digests for prediction-market agents. x402 pay-per-call on Base USDC, no API key.",
+  "url": "https://www.npmjs.com/package/moltalyzer-mcp",
+  "readme": "https://www.npmjs.com/package/moltalyzer-mcp",
+  "runtime": "node",
+  "env": {}
+}

--- a/packages/uncategorized/moltalyzer-mcp.json
+++ b/packages/uncategorized/moltalyzer-mcp.json
@@ -2,9 +2,15 @@
   "type": "mcp-server",
   "name": "Moltalyzer",
   "packageName": "moltalyzer-mcp",
-  "description": "Polymarket and AI-agent-community intelligence MCP server — order-book microstructure, whale-trader calibration, and market digests for prediction-market agents. x402 pay-per-call on Base USDC, no API key.",
+  "description": "Moltbook community-intelligence MCP server for searching posts, tracking trending discussions, analyzing sentiment, inspecting agents, and generating topic and activity digests. Includes free tools and optional x402 paid calls on Base USDC.",
   "url": "https://www.npmjs.com/package/moltalyzer-mcp",
   "readme": "https://www.npmjs.com/package/moltalyzer-mcp",
   "runtime": "node",
-  "env": {}
+  "env": {
+    "EVM_PRIVATE_KEY": {
+      "description": "Optional EVM private key used to pay for x402-protected tools on Base.",
+      "required": false,
+      "secret": true
+    }
+  }
 }

--- a/packages/uncategorized/vindex-mcp.json
+++ b/packages/uncategorized/vindex-mcp.json
@@ -2,9 +2,15 @@
   "type": "mcp-server",
   "name": "Vindex",
   "packageName": "vindex-mcp",
-  "description": "Vehicle-data MCP server — decode any VIN with factory warranty terms, plus safety recalls, known issues / reliability, and US/CA purchase-cost estimates (NHTSA + Transport Canada). x402 pay-per-call on Base USDC, no API key.",
+  "description": "Vehicle-data MCP server for VIN decoding, factory warranties, safety recalls, known issues, reliability, and US/Canada purchase-cost estimates. Includes free tools and optional x402 paid calls on Base USDC.",
   "url": "https://www.npmjs.com/package/vindex-mcp",
   "readme": "https://www.npmjs.com/package/vindex-mcp",
   "runtime": "node",
-  "env": {}
+  "env": {
+    "EVM_PRIVATE_KEY": {
+      "description": "Optional EVM private key used to pay for x402-protected tools on Base.",
+      "required": false,
+      "secret": true
+    }
+  }
 }

--- a/packages/uncategorized/vindex-mcp.json
+++ b/packages/uncategorized/vindex-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "name": "Vindex",
+  "packageName": "vindex-mcp",
+  "description": "Vehicle-data MCP server — decode any VIN with factory warranty terms, plus safety recalls, known issues / reliability, and US/CA purchase-cost estimates (NHTSA + Transport Canada). x402 pay-per-call on Base USDC, no API key.",
+  "url": "https://www.npmjs.com/package/vindex-mcp",
+  "readme": "https://www.npmjs.com/package/vindex-mcp",
+  "runtime": "node",
+  "env": {}
+}


### PR DESCRIPTION
Adds three published, live MCP servers (npm) that wrap x402 pay-per-call data APIs on Base USDC. Each runs via `npx` (runtime `node`) and needs no environment variables — agents pay per call over x402, so `env` is `{}`.

- **vindex-mcp** — vehicle data: VIN decode + factory warranty, recalls, known issues/reliability, US/CA purchase costs (NHTSA + Transport Canada). https://www.npmjs.com/package/vindex-mcp
- **isocast-mcp** — Polymarket weather-market signals (temperature-bucket crossings + live odds, 37 cities). https://www.npmjs.com/package/isocast-mcp
- **moltalyzer-mcp** — Polymarket + AI-agent-community intelligence (order-book microstructure, whale calibration, digests). https://www.npmjs.com/package/moltalyzer-mcp

Three JSON files added under `packages/uncategorized/` per the contributing guide, matching the required schema (`type`, `runtime`, `packageName`) with npm package links. No duplicates.