### PR TITLE
Add Taisly Agent Kit

### DIFF
--- a/packages/marketing/taisly-agent-kit.json
+++ b/packages/marketing/taisly-agent-kit.json
@@ -1,10 +1,12 @@
 {
   "type": "mcp-server",
   "name": "Taisly Agent Kit",
-  "packageName": "@taisly/agent",
+  "packageName": "@toolsdk-remote/taisly-agent-kit",
   "packageVersion": "0.2.8",
   "bin": "taisly",
-  "binArgs": ["mcp"],
+  "binArgs": [
+    "mcp"
+  ],
   "description": "Official MCP server for publishing and scheduling short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly.",
   "url": "https://github.com/taisly/agent",
   "readme": "https://github.com/taisly/agent#readme",

--- a/packages/marketing/taisly-agent-kit.json
+++ b/packages/marketing/taisly-agent-kit.json
@@ -1,0 +1,30 @@
+{
+  "type": "mcp-server",
+  "name": "Taisly Agent Kit",
+  "packageName": "@taisly/agent",
+  "packageVersion": "0.2.8",
+  "bin": "taisly",
+  "binArgs": ["mcp"],
+  "description": "Official MCP server for publishing and scheduling short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly.",
+  "url": "https://github.com/taisly/agent",
+  "readme": "https://github.com/taisly/agent#readme",
+  "logo": "https://app.taisly.com/logo512.png",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Taisly",
+  "env": {
+    "TAISLY_API_KEY": {
+      "description": "Optional Taisly API key for local MCP authentication.",
+      "required": false
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://app.taisly.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the official Taisly Agent Kit MCP server with both npm/stdio and hosted Streamable HTTP OAuth connection metadata.

- npm: `@taisly/agent@0.2.8`
- remote: `https://app.taisly.com/mcp`
- repository: https://github.com/taisly/agent