### PR TITLE
Add Spala Public MCP

### DIFF
--- a/packages/developer-tools/toolsdk-remote-ai-spala-public-mcp.json
+++ b/packages/developer-tools/toolsdk-remote-ai-spala-public-mcp.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "Spala Public MCP",
+  "packageName": "@toolsdk-remote/ai-spala-public-mcp",
+  "description": "Official public MCP for Spala's AI backend builder. Discover Spala, search documentation, inspect templates and addons, authenticate, select a project, and hand off to the exact project-scoped MCP URL for backend inspection, build, validation, and publishing.",
+  "url": "https://docs.spala.ai/agents/mcp/",
+  "readme": "https://spala.ai/mcp.md",
+  "runtime": "node",
+  "logo": "https://spala.ai/brand/icon-square.svg",
+  "author": "Spala AI",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.spala.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the official hosted Spala Public MCP as a Streamable HTTP remote server.

- Endpoint: `https://mcp.spala.ai/mcp`
- Public documentation: `https://docs.spala.ai/agents/mcp/`
- Machine-readable overview: `https://spala.ai/mcp.md`
- No credentials required for public discovery tools
- Authenticated tools handle project selection and handoff to project-scoped MCP endpoints

This contribution contains public registry metadata only. It does not include or expose Spala server source or private implementation details.

## Validation

- JSON schema validation passed
- Live Streamable HTTP connection succeeded
- `tools/list` returned 11 tools
- Biome check/format passed for the added file

The repository-wide pre-push check currently reports unrelated pre-existing formatting/lint findings outside this one-file change.