### PR TITLE
Add Nora MCP server

### DIFF
--- a/packages/uncategorized/nora.json
+++ b/packages/uncategorized/nora.json
@@ -1,0 +1,25 @@
+{
+  "type": "mcp-server",
+  "key": "nora",
+  "name": "Nora",
+  "packageName": "@noraai/mcp-server",
+  "description": "Operate self-hosted OpenClaw and Hermes agent fleets on Docker or Kubernetes through Nora's control plane, including deployment, lifecycle actions, monitoring, metrics, events, and per-agent cost.",
+  "url": "https://github.com/solomon2773/nora/tree/master/mcp-server",
+  "readme": "https://github.com/solomon2773/nora/blob/master/mcp-server/README.md",
+  "runtime": "node",
+  "license": "Apache-2.0",
+  "env": {
+    "NORA_API_URL": {
+      "description": "Base URL of the Nora backend API, for example https://nora.example.com",
+      "required": true
+    },
+    "NORA_API_KEY": {
+      "description": "Nora workspace API key with the scopes required by the tools you use",
+      "required": true
+    },
+    "NORA_MCP_ALLOW_DESTRUCTIVE": {
+      "description": "Set to true to register destructive tools such as delete_agent; disabled by default",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Nora, a stdio MCP server for deploying, monitoring, and operating self-hosted OpenClaw and Hermes agent fleets through the Nora control plane.

- npm: `@noraai/mcp-server` (current release `0.1.3`)
- runtime: Node.js 20+
- license: Apache-2.0
- repository subfolder and README URLs verified publicly accessible
- required and opt-in environment variables mirror the package README and published MCP registry metadata

## Validation

- `npx -y bun scripts/validate-package.ts packages/uncategorized/nora.json --schema-only`
- `npx -y @biomejs/biome check packages/uncategorized/nora.json`