### PR TITLE
Add DomScan remote MCP server

### DIFF
--- a/packages/security/domscan.json
+++ b/packages/security/domscan.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "DomScan",
+  "packageName": "@toolsdk-remote/domscan-mcp",
+  "description": "Domain intelligence for DNS, WHOIS/RDAP, TLS, reputation, valuation, email security, and brand protection.",
+  "url": "https://github.com/estevecastells/domscan-mcp",
+  "readme": "https://github.com/estevecastells/domscan-mcp#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://domscan.net/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds DomScan, a remote Streamable HTTP MCP server for domain intelligence.

DomScan provides tools for domain availability, DNS, WHOIS/RDAP, TLS, reputation, valuation, email security, and brand protection.

- Endpoint: https://domscan.net/mcp
- Repository: https://github.com/estevecastells/domscan-mcp
- Documentation: https://domscan.net/mcp-domain-checker
- Transport: Streamable HTTP
- Authentication: OAuth discovery, with API-key support for compatible clients

Validation: `bun scripts/validate-package.ts packages/security/domscan.json --schema-only`
