### PR TITLE
Add UIZZE MCP server to registry

### DIFF
--- a/packages/coding-agents/uizze.json
+++ b/packages/coding-agents/uizze.json
@@ -1,7 +1,6 @@
 {
   "type": "mcp-server",
   "name": "UIZZE",
-  "key": "uizze",
   "packageName": "@toolsdk-remote/io-github-samuelbushi-uizze",
   "description": "Real UI references, design contracts, validation, audits, and critiques for coding agents. The public catalog is free to browse; hosted MCP workflows require full access.",
   "url": "https://github.com/uizze/uizze-mcp",

--- a/packages/coding-agents/uizze.json
+++ b/packages/coding-agents/uizze.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "UIZZE",
+  "key": "uizze",
+  "packageName": "@toolsdk-remote/io-github-samuelbushi-uizze",
+  "description": "Real UI references, design contracts, validation, audits, and critiques for coding agents. The public catalog is free to browse; hosted MCP workflows require full access.",
+  "url": "https://github.com/aislon/uizze-mcp",
+  "runtime": "node",
+  "env": {
+    "UIZZE_AGENT_TOKEN": {
+      "description": "UIZZE agent token for the full-access hosted MCP workflow.",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://uizze.com/mcp"
+    }
+  ]
+}

--- a/packages/coding-agents/uizze.json
+++ b/packages/coding-agents/uizze.json
@@ -4,7 +4,7 @@
   "key": "uizze",
   "packageName": "@toolsdk-remote/io-github-samuelbushi-uizze",
   "description": "Real UI references, design contracts, validation, audits, and critiques for coding agents. The public catalog is free to browse; hosted MCP workflows require full access.",
-  "url": "https://github.com/aislon/uizze-mcp",
+  "url": "https://github.com/uizze/uizze-mcp",
   "runtime": "node",
   "env": {
     "UIZZE_AGENT_TOKEN": {


### PR DESCRIPTION
## Summary

- Add the hosted UIZZE Streamable HTTP MCP server to Coding Agents.
- Link the official connector repository and declare the required UIZZE agent token.
- Preserve the product boundary: the public catalog is free to browse; hosted MCP workflows require full access.

## Why

UIZZE gives coding agents real UI references, design contracts, validation, audits, and critiques before implementation. This structured entry makes its existing remote MCP endpoint discoverable through the ToolSDK registry.

## Validation

- `pnpm exec tsx scripts/validate-package.ts packages/coding-agents/uizze.json --schema-only`
- `pnpm exec biome check packages/coding-agents/uizze.json --diagnostic-level=error`
- `git diff --check`
- Verified `https://uizze.com/` and `https://github.com/aislon/uizze-mcp` return HTTP 200.
- Verified an unauthenticated MCP initialize request returns HTTP 401 with `Missing bearer token.` as expected.

The focused package suite has the same unrelated pre-existing assertion failure on upstream `main` (12 passing, 1 failing in `package-so.test.ts`: one argument expected while the implementation supplies a second `undefined` argument).
