### PR TITLE
Add GoodMemory MCP server to knowledge and memory

### DIFF
--- a/packages/knowledge-memory/goodmemory.json
+++ b/packages/knowledge-memory/goodmemory.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "GoodMemory",
+  "packageName": "goodmemory",
+  "description": "Local-first, auditable memory layer for AI agents with durable SQLite storage, BM25 recall, read-only inspection tools, and opt-in governed writeback.",
+  "url": "https://github.com/hjqcan/GoodMemory",
+  "readme": "https://github.com/hjqcan/GoodMemory#standalone-mcp-for-any-client",
+  "runtime": "node",
+  "bin": "goodmemory-mcp",
+  "binArgs": ["--standalone"],
+  "license": "MIT",
+  "env": {
+    "GOODMEMORY_USER_ID": {
+      "description": "Stable user identifier used to scope standalone memory",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds GoodMemory to the Knowledge & Memory category.

GoodMemory is a local-first, auditable memory layer for AI agents and coding hosts. The npm package exposes the `goodmemory-mcp` binary; standalone mode uses a stable `GOODMEMORY_USER_ID` for memory scope and stores data in durable local SQLite by default.

## Metadata

- Package: `goodmemory`
- Binary: `goodmemory-mcp --standalone`
- License: MIT
- Repository: https://github.com/hjqcan/GoodMemory

## Validation

- `git diff --check`
- `make validate packages/knowledge-memory/goodmemory.json`
- npm metadata verified for `goodmemory@0.5.1`

Schema validation passes. The connection test is skipped locally because the registry checkout does not install submitted packages.
