### PR TITLE
Add Fanvault remote MCP server

### DIFF
--- a/packages/marketing/fanvault.json
+++ b/packages/marketing/fanvault.json
@@ -2,7 +2,6 @@
   "type": "mcp-server",
   "runtime": "node",
   "packageName": "@toolsdk-remote/io-github-thefanvault-fanvault",
-  "key": "fanvault",
   "name": "Fanvault",
   "description": "Run creator storefronts, listings, digital products, orders, content, fulfillment, messages, and analytics through AI.",
   "readme": "https://raw.githubusercontent.com/thefanvault/fanvault-mcp/main/README.md",

--- a/packages/marketing/fanvault.json
+++ b/packages/marketing/fanvault.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "runtime": "node",
+  "packageName": "@toolsdk-remote/io-github-thefanvault-fanvault",
+  "key": "fanvault",
+  "name": "Fanvault",
+  "description": "Run creator storefronts, listings, digital products, orders, content, fulfillment, messages, and analytics through AI.",
+  "readme": "https://raw.githubusercontent.com/thefanvault/fanvault-mcp/main/README.md",
+  "url": "https://github.com/thefanvault/fanvault-mcp",
+  "license": "proprietary",
+  "logo": "https://raw.githubusercontent.com/thefanvault/fanvault-mcp/main/assets/icon-512.png",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://fanvault.shop/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Fanvault as a hosted Streamable HTTP MCP server with OAuth 2.1 authentication. The server helps creators manage listings, digital products, orders, fulfillment, content, messages, and analytics.

## Verification

- Official MCP Registry: `io.github.thefanvault/fanvault` v1.0.0 (active)
- Endpoint: `https://fanvault.shop/mcp`
- Documentation: https://fanvault.shop/developers/mcp
- Public metadata: https://github.com/thefanvault/fanvault-mcp
- `bun scripts/validate-package.ts packages/marketing/fanvault.json --schema-only` passed

The runtime field is `node` as required by the registry schema; this entry uses the `remotes` transport and does not install a local package.