### PR TITLE
Add Adlicio MCP server

### DIFF
--- a/packages/uncategorized/adlicio.json
+++ b/packages/uncategorized/adlicio.json
@@ -1,14 +1,15 @@
 {
   "type": "mcp-server",
-  "key": "adlicio",
   "name": "Adlicio",
-  "packageName": "commentscraper",
+  "packageName": "@toolsdk-remote/adlicio",
   "description": "Research customer language, pain points, sentiment, and market themes from Reddit discussions and comments across supported review and community platforms.",
   "readme": "https://tryadlicio.com/mcp",
   "url": "https://github.com/daniel-ddtech/commentscraper-cli",
   "runtime": "node",
   "bin": "commentscraper",
-  "binArgs": ["mcp"],
+  "binArgs": [
+    "mcp"
+  ],
   "author": "DDTechSolution",
   "env": {},
   "remotes": [
@@ -17,7 +18,9 @@
       "url": "https://mcp.tryadlicio.com/mcp",
       "auth": {
         "type": "oauth2",
-        "scopes": ["mcp:tools"]
+        "scopes": [
+          "mcp:tools"
+        ]
       }
     }
   ]

--- a/packages/uncategorized/adlicio.json
+++ b/packages/uncategorized/adlicio.json
@@ -5,6 +5,7 @@
   "packageName": "commentscraper",
   "description": "Research customer language, pain points, sentiment, and market themes from Reddit discussions and comments across supported review and community platforms.",
   "readme": "https://tryadlicio.com/mcp",
+  "url": "https://github.com/daniel-ddtech/commentscraper-cli",
   "runtime": "node",
   "bin": "commentscraper",
   "binArgs": ["mcp"],

--- a/packages/uncategorized/adlicio.json
+++ b/packages/uncategorized/adlicio.json
@@ -1,0 +1,23 @@
+{
+  "type": "mcp-server",
+  "key": "adlicio",
+  "name": "Adlicio",
+  "packageName": "commentscraper",
+  "description": "Research customer language, pain points, sentiment, and market themes from Reddit discussions and comments across supported review and community platforms.",
+  "readme": "https://tryadlicio.com/mcp",
+  "runtime": "node",
+  "bin": "commentscraper",
+  "binArgs": ["mcp"],
+  "author": "DDTechSolution",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.tryadlicio.com/mcp",
+      "auth": {
+        "type": "oauth2",
+        "scopes": ["mcp:tools"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Adlicio with both supported connection paths:

- Local stdio via the published `commentscraper` npm package and `commentscraper mcp`
- Hosted Streamable HTTP at `https://mcp.tryadlicio.com/mcp` with OAuth 2.1 and the `mcp:tools` scope

Adlicio provides customer-research tools for finding Reddit discussions and extracting comments and reviews from supported community platforms.

## Validation

- JSON syntax: passed
- ToolSDK Zod schema: passed
- Product and setup documentation: HTTP 200
- OAuth protected-resource metadata: HTTP 200
- OAuth authorization-server metadata: HTTP 200
- npm package verified: `commentscraper@1.3.3`, binary `commentscraper`

The unauthenticated connectivity probe returns the expected HTTP 401 because the endpoint is OAuth-protected; repository CI uses schema-only validation for changed package JSON files.