### PR TITLE
Add iLoveVideoEditor MCP server to registry

### DIFF
--- a/packages/uncategorized/ilovevideoeditor.json
+++ b/packages/uncategorized/ilovevideoeditor.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "iLoveVideoEditor",
+  "packageName": "@ilovevideoeditor/mcp-server",
+  "description": "Render videos from JSON via the iLoveVideoEditor cloud API: motion-design templates, GPU effects, transitions, batch rendering, webhooks.",
+  "url": "https://github.com/ilovevideoeditor/mcp-server",
+  "runtime": "node",
+  "license": "Apache-2.0",
+  "env": {
+    "VF_API_KEY": {
+      "description": "iLoveVideoEditor API key (generate at ilovevideoeditor.com/dashboard/account/api)",
+      "required": true
+    },
+    "VF_API_BASE_URL": {
+      "description": "API base URL override",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
Adds packages/uncategorized/ilovevideoeditor.json for [ilovevideoeditor/mcp-server](https://github.com/ilovevideoeditor/mcp-server) — an MCP server that renders videos from JSON via the iLoveVideoEditor cloud API: motion-design templates, GPU effects, transitions, batch rendering, webhooks. Runtime: node, npm package @ilovevideoeditor/mcp-server (stdio; API key via VF_API_KEY), Apache-2.0, also on the official MCP Registry (io.github.ilovevideoeditor/mcp-server). Placed in uncategorized per the contributing guide.