### PR TITLE
Add RunComfy MCP

### DIFF
--- a/packages/uncategorized/runcomfy-mcp.json
+++ b/packages/uncategorized/runcomfy-mcp.json
@@ -3,7 +3,8 @@
   "name": "RunComfy MCP",
   "packageName": "@toolsdk-remote/runcomfy-mcp",
   "description": "Official remote MCP server for the RunComfy Serverless API (ComfyUI): create and manage GPU deployments, run async inference, and retrieve image/video results.",
-  "url": "https://github.com/runcomfy-com/runcomfy-mcp",
+  "url": "https://www.runcomfy.com",
+  "logo": "https://github.com/runcomfy-com.png",
   "runtime": "node",
   "license": "MIT",
   "env": {

--- a/packages/uncategorized/runcomfy-mcp.json
+++ b/packages/uncategorized/runcomfy-mcp.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "RunComfy MCP",
+  "packageName": "@toolsdk-remote/runcomfy-mcp",
+  "description": "Official remote MCP server for the RunComfy Serverless API (ComfyUI): create and manage GPU deployments, run async inference, and retrieve image/video results.",
+  "url": "https://github.com/runcomfy-com/runcomfy-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "RUNCOMFY_API_KEY": {
+      "description": "RunComfy API token, sent as 'Authorization: Bearer <token>'. Get it from https://www.runcomfy.com/profile",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.runcomfy.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Add RunComfy MCP

Adds `packages/uncategorized/runcomfy-mcp.json` — the **official first-party remote MCP server** for the [RunComfy Serverless API (ComfyUI)](https://docs.runcomfy.com/mcp): create and manage GPU deployments, run async inference, and retrieve image/video results.

- **Repo**: https://github.com/runcomfy-com/runcomfy-mcp (MIT, Python/FastMCP)
- **Remote endpoint**: `https://mcp.runcomfy.com/mcp` (streamable-http)
- **Auth**: `Authorization: Bearer <token>` — token from https://www.runcomfy.com/profile (documented via the `RUNCOMFY_API_KEY` env entry)
- **Official MCP registry**: published as `io.github.runcomfy-com/runcomfy-mcp`
- **10 tools**: list/get/create/update/delete_deployment, submit_request, get_request_status, get_request_result, cancel_request, call_instance_proxy

Follows the same remote-server conventions as `aiskillstore.json` / `toolrouter.json` (`@toolsdk-remote/` packageName, `remotes` array).

### Validation

Ran `make validate packages/uncategorized/runcomfy-mcp.json` locally:

```
✅ Valid JSON
✅ Schema validation passed
🔌 Connecting to MCP server...
✅ validated: true — 10 tool(s) found
```