### PR TITLE
Add glm-mcp to coding-agents

### DIFF
--- a/packages/coding-agents/glm-mcp.json
+++ b/packages/coding-agents/glm-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "packageName": "glm-mcp",
+  "description": "Run GLM (Zhipu/Z.ai) as a real sub-agent inside Claude Code, GitHub Copilot, or Codex — its own read/write/edit/run agent loop on your repo with peak-aware Opus-vs-GLM routing and diff/dry-run/git-revert oversight. ~10x cheaper than Opus.",
+  "url": "https://github.com/djerok/glm-mcp",
+  "runtime": "node",
+  "license": "mit",
+  "env": {
+    "GLM_API_KEY": {
+      "description": "Z.ai / Zhipu GLM Coding Plan API key",
+      "required": true
+    }
+  },
+  "name": "GLM Subagent MCP"
+}


### PR DESCRIPTION
Adds GLM Subagent MCP (`glm-mcp`, published on npm) to the `coding-agents` category. It runs GLM (Zhipu/Z.ai) as a real file-editing sub-agent for Claude Code / GitHub Copilot / Codex, with its own read/write/edit/run loop, peak-aware routing, and diff/dry-run/git-revert oversight. Repo: https://github.com/djerok/glm-mcp