### PR TITLE
Refresh Memi MCP package

### DIFF
--- a/packages/developer-tools/memoire.json
+++ b/packages/developer-tools/memoire.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "@sarveshsea/memoire",
-  "bin": "memi",
-  "binArgs": ["mcp"],
-  "description": "MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes.",
-  "url": "https://github.com/sarveshsea/m-moire",
+  "packageName": "@memi-design/cli",
+  "binArgs": ["mcp", "start", "--no-figma"],
+  "description": "Agent design CI and interface understanding for coding agents, with focused Agent Skills and 47 MCP tools for UI audits, tokens, component structure, accessibility, and handoff receipts.",
+  "url": "https://github.com/sarveshsea/memi",
   "runtime": "node",
   "license": "MIT",
   "env": {},
-  "name": "Memoire"
+  "name": "Memi"
 }


### PR DESCRIPTION
## Summary

- replace the retired `@sarveshsea/memoire` package with `@memi-design/cli`
- update the repository and product name to Memi
- use the current `mcp start --no-figma` arguments
- let ToolSDK resolve the package executable from its npm manifest

## Verification

`bun scripts/validate-package.ts packages/developer-tools/memoire.json` passes schema validation and connects successfully to all **47 MCP tools** from `@memi-design/cli@2.5.0`.

The repository-wide pre-push Biome check currently reports unrelated existing formatting errors outside this one-file change; the changed JSON itself passes the pre-commit Biome checks.