### PR TITLE
Add BeachFinder remote MCP server

### DIFF
--- a/packages/location-services/beachfinder.json
+++ b/packages/location-services/beachfinder.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "packageName": "com.getbeachfinder/beachfinder",
+  "name": "BeachFinder",
+  "description": "Search and compare 184,900 beaches, lakes, and swimming spots worldwide with current planning signals, water activities, public providers, source attribution, and canonical BeachFinder links through a read-only remote MCP server.",
+  "url": "https://github.com/troulin-a11y/BeachFinder-mcp",
+  "readme": "https://github.com/troulin-a11y/BeachFinder-mcp/blob/main/README.md",
+  "logo": "https://getbeachfinder.com/logo.png",
+  "runtime": "node",
+  "env": {},
+  "author": "BeachFinder",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://getbeachfinder.com/mcp"
+    }
+  ]
+}

--- a/packages/location-services/beachfinder.json
+++ b/packages/location-services/beachfinder.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "com.getbeachfinder/beachfinder",
+  "packageName": "@toolsdk-remote/beachfinder",
   "name": "BeachFinder",
   "description": "Search and compare 184,900 beaches, lakes, and swimming spots worldwide with current planning signals, water activities, public providers, source attribution, and canonical BeachFinder links through a read-only remote MCP server.",
   "url": "https://github.com/troulin-a11y/BeachFinder-mcp",


### PR DESCRIPTION
## Summary

Adds the hosted BeachFinder MCP server to the location-services registry.

- Official registry ID: com.getbeachfinder/beachfinder
- Remote transport: Streamable HTTP
- Endpoint: https://getbeachfinder.com/mcp
- Authentication: none
- Public metadata: https://github.com/troulin-a11y/BeachFinder-mcp

BeachFinder exposes 12 bounded, read-only tools for 184,900 beaches, lakes, and swimming spots, current planning signals, water activities, public providers, guides, and anonymous community summaries. It does not expose private provider contacts and never declares swimming safe.

## Validation

- JSON parses successfully and matches the documented remote-server schema fields.
- The live endpoint passes the BeachFinder 12-tool MCP, privacy, rate-limit, and abuse test suite.
- No environment variables or secrets are required.

The repository's full validation script could not be run in the clean fork without installing its large dependency set; upstream CI remains the final schema check.