### PR TITLE
fix(finance-fintech): refresh Frihet MCP entry — 31→157 tools + EU e-invoicing

### DIFF
--- a/packages/finance-fintech/frihet-mcp.json
+++ b/packages/finance-fintech/frihet-mcp.json
@@ -2,7 +2,7 @@
   "type": "mcp-server",
   "name": "Frihet",
   "packageName": "@toolsdk-remote/frihet-mcp-server",
-  "description": "AI-native business management MCP server with 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance (VeriFactu). Supports multi-currency (40 currencies), OCR, Stripe Connect, and webhooks.",
+  "description": "AI-native ERP MCP server with 157 tools for invoicing, expenses, clients, products, quotes, CRM, banking, and accounting, plus native Spanish/EU e-invoicing compliance (VeriFactu, TicketBAI, Facturae). 100+ integrations, progressive tool disclosure, idempotency-keyed mutations, and a remote OAuth 2.0 endpoint at mcp.frihet.io. MIT.",
   "url": "https://github.com/Frihet-io/frihet-mcp",
   "runtime": "node",
   "license": "MIT",


### PR DESCRIPTION
The existing Frihet entry (`packages/finance-fintech/frihet-mcp.json`) had a stale `description`: it advertised **31 tools**, 40 currencies, and Stripe Connect. The server now ships **157 tools** (invoicing, expenses, clients, products, quotes, CRM, banking, accounting) with native Spanish/EU e-invoicing compliance (VeriFactu, TicketBAI, Facturae) and 100+ integrations exposed over the remote OAuth 2.0 endpoint at mcp.frihet.io. This is a single-field `description` refresh — no other fields (type, name, packageName, url, runtime, license, env, remotes) are touched. Schema validation passes:

```
$ make validate packages/finance-fintech/frihet-mcp.json --schema-only
✅ Valid JSON
✅ Schema validation passed
✅ Schema-only validation complete (connection test skipped)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)