### PR TITLE
Add find-mcp MCP server

### DIFF
--- a/packages/aggregators/find-mcp.json
+++ b/packages/aggregators/find-mcp.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "Find MCP",
+  "packageName": "@agentage/find-mcp",
+  "description": "Search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io) via the agentage MCP Catalog",
+  "url": "https://github.com/agentage/find-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "agentage",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://catalog.agentage.io/mcp"
+    }
+  ]
+}

--- a/packages/aggregators/find-mcp.json
+++ b/packages/aggregators/find-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Find MCP",
-  "packageName": "@agentage/find-mcp",
+  "packageName": "@toolsdk-remote/find-mcp",
   "description": "Search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io) via the agentage MCP Catalog",
   "url": "https://github.com/agentage/find-mcp",
   "runtime": "node",


### PR DESCRIPTION
## What

Adds `packages/aggregators/find-mcp.json` for **Find MCP** - an MCP server for discovering other MCP servers, searching the agentage MCP Catalog (17,000+ servers synced from the official MCP registry, registry.modelcontextprotocol.io).

## Where

- GitHub: https://github.com/agentage/find-mcp
- npm: `@agentage/find-mcp` (stdio: `npx -y @agentage/find-mcp`)
- Remote: Streamable HTTP `https://catalog.agentage.io/mcp` (no auth needed for search)
- Web UI: https://catalog.agentage.io/mcp
- Official registry entry: `io.agentage/find-mcp`
- License: MIT (verified from repo LICENSE file)

## Details

- `type`: `mcp-server`, `runtime`: `node`, `packageName`: `@agentage/find-mcp`
- Includes a `remotes` entry for the hosted Streamable HTTP endpoint (no auth), following the pattern used by other remote-capable entries in this registry.
- JSON validated to parse correctly.

Disclosure: I maintain Find MCP.
