### PR TITLE
feat(security): add SPARDA Security Gate

### DIFF
--- a/packages/security/sparda-skills.json
+++ b/packages/security/sparda-skills.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "name": "SPARDA Security Gate",
+  "packageName": "@residual-labs/sparda",
+  "description": "Connects AI coding agents (Claude Code, Cursor, Windsurf) to the SPARDA Security Gate to validate edits via Proof-Carrying Code (PCC) invariants before applying them.",
+  "url": "https://github.com/zyx77550/sparda-skills",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {}
+}

--- a/packages/security/sparda-skills.json
+++ b/packages/security/sparda-skills.json
@@ -1,10 +1,11 @@
 {
   "type": "mcp-server",
   "name": "SPARDA Security Gate",
-  "packageName": "@residual-labs/sparda",
+  "packageName": "sparda-mcp",
   "description": "Connects AI coding agents (Claude Code, Cursor, Windsurf) to the SPARDA Security Gate to validate edits via Proof-Carrying Code (PCC) invariants before applying them.",
-  "url": "https://github.com/zyx77550/sparda-skills",
+  "url": "https://github.com/zyx77550/sparda",
+  "readme": "https://github.com/zyx77550/sparda#readme",
   "runtime": "node",
-  "license": "MIT",
+  "license": "BUSL-1.1",
   "env": {}
 }


### PR DESCRIPTION
Added SPARDA Security Gate, an MCP server that connects AI coding agents (Claude Code, Cursor) to validate edits via Proof-Carrying Code (PCC) invariants before applying them.