### PR TITLE
Add Chainflip Broker as a Service to finance-fintech

### DIFF
--- a/packages/finance-fintech/chainflip-broker-as-a-service.json
+++ b/packages/finance-fintech/chainflip-broker-as-a-service.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "Chainflip Broker as a Service",
+  "packageName": "chainflip-broker-baas",
+  "key": "chainflip-broker-baas",
+  "description": "Cross-chain cryptocurrency swaps via the Chainflip protocol. Get quotes, execute simple or DCA swaps between native BTC, ETH, SOL, and more, and track swap progress. Hosted remote server, no API key required.",
+  "url": "https://github.com/CumpsD/broker-as-a-service",
+  "readme": "https://docs.chainflip-broker.io/resources/ai-documentation/",
+  "runtime": "node",
+  "author": "CumpsD",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://chainflip-broker.io/mcp"
+    }
+  ]
+}

--- a/packages/finance-fintech/chainflip-broker-as-a-service.json
+++ b/packages/finance-fintech/chainflip-broker-as-a-service.json
@@ -1,8 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Chainflip Broker as a Service",
-  "packageName": "chainflip-broker-baas",
-  "key": "chainflip-broker-baas",
+  "packageName": "@toolsdk-remote/chainflip-broker-as-a-service",
   "description": "Cross-chain cryptocurrency swaps via the Chainflip protocol. Get quotes, execute simple or DCA swaps between native BTC, ETH, SOL, and more, and track swap progress. Hosted remote server, no API key required.",
   "url": "https://github.com/CumpsD/broker-as-a-service",
   "readme": "https://docs.chainflip-broker.io/resources/ai-documentation/",


### PR DESCRIPTION
Adds Chainflip Broker as a Service to `packages/finance-fintech`, following docs/CONTRIBUTING.md.

- Remote-only hosted MCP server, Streamable HTTP at `https://chainflip-broker.io/mcp`, open endpoint, no auth and no env vars needed.
- Cross-chain cryptocurrency swaps via the Chainflip protocol: quotes, simple or DCA swap execution, and swap status tracking between native BTC, ETH, SOL, and more.
- Listed in the official MCP Registry as `io.chainflip-broker/baas`.
- Docs: https://docs.chainflip-broker.io/resources/ai-documentation/

Placed directly in finance-fintech (next to the existing cross-chain swap entries) rather than uncategorized.