### PR TITLE
Add Webhound MCP server

### DIFF
--- a/packages/search-data-extraction/webhound-mcp.json
+++ b/packages/search-data-extraction/webhound-mcp.json
@@ -1,8 +1,7 @@
 {
   "type": "mcp-server",
-  "key": "webhound-mcp",
   "name": "Webhound",
-  "packageName": "webhound-mcp",
+  "packageName": "@toolsdk-remote/webhound-mcp",
   "description": "Webhound lets an agent set a prompt and dollar budget for a long-running web investigation, then retrieve cited reports or datasets plus working documents, sources, claims, limitations, and evidence packs.",
   "readme": "https://github.com/WebhoundAI/webhound-mcp#readme",
   "url": "https://github.com/WebhoundAI/webhound-mcp",
@@ -21,7 +20,9 @@
       "url": "https://api.webhound.ai/api/v2/mcp",
       "auth": {
         "type": "oauth2",
-        "scopes": ["webhound:mcp"]
+        "scopes": [
+          "webhound:mcp"
+        ]
       }
     }
   ]

--- a/packages/search-data-extraction/webhound-mcp.json
+++ b/packages/search-data-extraction/webhound-mcp.json
@@ -1,0 +1,28 @@
+{
+  "type": "mcp-server",
+  "key": "webhound-mcp",
+  "name": "Webhound",
+  "packageName": "webhound-mcp",
+  "description": "Webhound lets an agent set a prompt and dollar budget for a long-running web investigation, then retrieve cited reports or datasets plus working documents, sources, claims, limitations, and evidence packs.",
+  "readme": "https://github.com/WebhoundAI/webhound-mcp#readme",
+  "url": "https://github.com/WebhoundAI/webhound-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Webhound",
+  "env": {
+    "WEBHOUND_KEY": {
+      "description": "Webhound API key for local stdio use",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.webhound.ai/api/v2/mcp",
+      "auth": {
+        "type": "oauth2",
+        "scopes": ["webhound:mcp"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Webhound to the search and data extraction category with:

- the `webhound-mcp` npm package for local stdio clients
- the hosted Streamable HTTP endpoint with OAuth 2.1
- a description centered on prompt-plus-dollar-budget research and inspectable evidence

## Validation

- `make validate packages/search-data-extraction/webhound-mcp.json`
  - schema validation passed
  - authenticated hosted connection passed
  - ToolSDK found all 30 tools
- `npx -y webhound-mcp@0.4.2 --self-test`
  - package loaded
  - all 30 required tools were present
- `./node_modules/.bin/biome check packages/search-data-extraction/webhound-mcp.json`
  - no errors

ToolSDK's validator does not complete OAuth itself, so I supplied a temporary Webhound bearer credential at runtime for the connection test. This change contains no credential.
