### PR TITLE
Add Equibles (US stock market data)

### DIFF
--- a/packages/finance-fintech/equibles.json
+++ b/packages/finance-fintech/equibles.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "packageName": "equibles",
+  "name": "Equibles",
+  "description": "US stock market data over MCP: live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F institutional holdings, earnings-call transcripts, short interest, and FRED macro series. 90+ tools.",
+  "url": "https://github.com/daniel3303/stock-market-mcp-server",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.equibles.com/mcp"
+    }
+  ]
+}

--- a/packages/finance-fintech/equibles.json
+++ b/packages/finance-fintech/equibles.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "equibles",
+  "packageName": "@toolsdk-remote/equibles",
   "name": "Equibles",
   "description": "US stock market data over MCP: live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F institutional holdings, earnings-call transcripts, short interest, and FRED macro series. 90+ tools.",
   "url": "https://github.com/daniel3303/stock-market-mcp-server",


### PR DESCRIPTION
Adds Equibles under finance-fintech.

US stock market data over MCP: live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F institutional holdings, earnings-call transcripts, short interest, and FRED macro series. 90+ tools.

Hosted over Streamable HTTP at `https://mcp.equibles.com/mcp` with a free API key or OAuth; also self-hostable.