### PR TITLE
Add OpenPost MCP server

### DIFF
--- a/packages/marketing/openpost.json
+++ b/packages/marketing/openpost.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "OpenPost",
+  "packageName": "ghcr.io/rodrgds/openpost",
+  "description": "Open-source social publishing and scheduling with an authenticated MCP server for preparing destination-specific content, reusing media, validating, scheduling, publishing, and inspecting delivery status.",
+  "url": "https://github.com/rodrgds/openpost",
+  "readme": "https://docs.openpost.social/mcp/",
+  "runtime": "docker",
+  "license": "AGPL-3.0-only",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://app.openpost.social/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}

--- a/packages/marketing/openpost.json
+++ b/packages/marketing/openpost.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "OpenPost",
-  "packageName": "ghcr.io/rodrgds/openpost",
+  "packageName": "@toolsdk-remote/openpost",
   "description": "Open-source social publishing and scheduling with an authenticated MCP server for preparing destination-specific content, reusing media, validating, scheduling, publishing, and inspecting delivery status.",
   "url": "https://github.com/rodrgds/openpost",
   "readme": "https://docs.openpost.social/mcp/",


### PR DESCRIPTION
Adds OpenPost as a Docker-hosted MCP server with its AGPL repository, documentation, managed Streamable HTTP endpoint, and OAuth 2.0 metadata.

Disclosure: I maintain OpenPost.