### PR TITLE
feat: add safe registry PR validation workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ env:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
 
@@ -21,33 +21,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "pnpm"
 
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Test registry validator
+        run: node --test scripts/lib/registry-validator.node-test.mjs
 
       - name: Validate changed package JSON files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          mapfile -t files < <(git diff --name-only "$BASE_SHA...HEAD" -- 'packages/**/*.json')
-
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No changed package JSON files to validate."
-            exit 0
-          fi
-
-          for file in "${files[@]}"; do
-            if [ -f "$file" ]; then
-              bun scripts/validate-package.ts "$file" --schema-only
-            fi
-          done
+        run: node scripts/validate-registry.mjs --base "$BASE_SHA" --format github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Registry Agent Instructions
+
+When reviewing or merging registry pull requests, follow `docs/PR_REVIEW.md`.
+
+- Use the validator from the trusted `main` branch to inspect pull request JSON. Do not execute
+  scripts from a contributor branch.
+- Never install or run an MCP package submitted by a pull request.
+- Never merge, enable auto-merge, close, comment on, or modify a pull request without the user
+  authorizing that specific action.
+- Merge approval is valid only for the reported pull request number and exact head commit SHA.
+- Before an approved merge, refresh the pull request state and invalidate approval if its head SHA
+  or validation result changed.
+- Use squash merge with `--match-head-commit`. Never bypass checks with `--admin`.
+- Review and merge pull requests serially against the latest `main` so key collision checks remain
+  current.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,6 +70,9 @@ Each environment variable in the `env` object should have:
 
 - `description` (string): A brief description of what the variable is used for
 - `required` (boolean): Whether the variable is required
+- `default` (string, optional): A non-secret default value
+- `secret` (boolean, optional): Whether clients should treat the value as sensitive. Secret values
+  cannot define defaults.
 
 ## 🌐 Remote MCP Servers
 
@@ -79,7 +82,7 @@ If your MCP server supports remote hosting via Streamable HTTP transport, you ca
 {
   "type": "mcp-server",
   "name": "Remote GitHub MCP Server",
-  "packageName": "github-mcp",
+  "packageName": "@toolsdk-remote/github-mcp",
   "description": "A GitHub automation tool with remote hosting support",
   "runtime": "node",
   "env": {},
@@ -100,7 +103,7 @@ For MCP servers that require OAuth 2.1 authentication, add the `auth` configurat
 {
   "type": "mcp-server",
   "name": "OAuth GitHub MCP Server",
-  "packageName": "github-mcp",
+  "packageName": "@toolsdk-remote/github-mcp",
   "description": "GitHub MCP with OAuth authentication",
   "runtime": "node",
   "env": {},
@@ -128,6 +131,14 @@ For MCP servers that require OAuth 2.1 authentication, add the `auth` configurat
 | `auth.scopes` | string[] | No       | OAuth scopes to request                                  |
 
 > *Required when `auth` object is provided
+
+Every configuration with a non-empty `remotes` array must use a `packageName` beginning with
+`@toolsdk-remote/`. Remote endpoints must use HTTPS and cannot point to localhost or a private
+network. Remote configurations cannot define a custom `key`; their `packageName` is also their
+registry and gateway identity.
+
+New package keys must be unique. The registry uses `key` when provided and otherwise falls back to
+`packageName`; a new file cannot reuse an identity already present in the registry.
 
 ## 💻 Code Contributions
 

--- a/docs/PR_REVIEW.md
+++ b/docs/PR_REVIEW.md
@@ -1,0 +1,83 @@
+# Registry Pull Request Review
+
+Registry pull requests are reviewed in two stages: deterministic validation and an agent review.
+Passing CI is required, but it is not sufficient for merging.
+
+## Registry Rules
+
+- Package JSON must match the strict registry schema. Unknown fields are rejected.
+- A package with a non-empty `remotes` array must use a `packageName` beginning with
+  `@toolsdk-remote/`.
+- A package beginning with `@toolsdk-remote/` must define at least one remote endpoint.
+- A remote package cannot define a custom `key`; its `packageName` is its registry and gateway
+  identity.
+- Remote endpoints must use HTTPS and cannot target localhost or private networks.
+- A new file cannot reuse a `key`, or the fallback `packageName`, already present on the base
+  branch.
+- Existing historical key collisions are tolerated only while unchanged. A pull request cannot
+  introduce a new collision.
+- New package files must be placed directly in a configured category and use a lowercase
+  kebab-case filename.
+- Secret environment variables cannot define default values.
+
+Run deterministic validation with:
+
+```bash
+node scripts/validate-registry.mjs --base origin/main
+```
+
+Validate the complete working tree with:
+
+```bash
+node scripts/validate-registry.mjs --all
+```
+
+## Agent Review
+
+The agent reviews one pull request at a time against the latest `main`. It must:
+
+1. Record the pull request number and exact head commit SHA.
+2. Inspect every changed file and reject unrelated repository, workflow, or dependency changes.
+3. Run the trusted validator from `main` against a detached worktree containing the pull request.
+4. Verify package or repository ownership, license, remote domain, configuration claims, and
+   duplicates that are not fully covered by deterministic validation.
+5. Never install or execute a package submitted by a pull request.
+6. Present a review report containing the verdict, head SHA, changed files, checks, warnings, and
+   proposed merge method.
+7. Ask for explicit approval to merge that pull request at that head SHA.
+
+An invalid pull request is reported with blocking findings and is not offered for merge. Posting a
+review comment, closing a pull request, or modifying a contributor branch requires separate user
+approval.
+
+To avoid executing code from the contributor branch, create a detached worktree and invoke the
+validator from the trusted checkout while pointing `--root` at that worktree:
+
+```bash
+review_dir=$(mktemp -d)/pr
+git fetch origin "pull/${pr_number}/head:refs/codex/review/${pr_number}"
+git worktree add --detach "$review_dir" "refs/codex/review/${pr_number}"
+node scripts/validate-registry.mjs --root "$review_dir" --base origin/main
+git worktree remove "$review_dir"
+```
+
+## Merge Approval
+
+Approval applies to one pull request and one head SHA. Immediately before merging, the agent must
+refresh the pull request and confirm that:
+
+- the head SHA is unchanged;
+- the pull request is not a draft;
+- required checks passed;
+- the pull request is mergeable and has no unresolved blocking discussion;
+- the key remains unique against the latest `main`.
+
+If any of these conditions changed, the approval expires and the agent must present a new report.
+An approved registry pull request is squash-merged with head matching enabled:
+
+```bash
+gh pr merge <number> --squash --match-head-commit <full-head-sha>
+```
+
+The agent must not use `--admin` or `--auto`. After merging, it reports the resulting commit and
+refreshes `main` before reviewing the next pull request.

--- a/package.json
+++ b/package.json
@@ -71,8 +71,10 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:package": "vitest run src/domains/package",
+    "test:registry-validator": "node --test scripts/lib/registry-validator.node-test.mjs",
     "test:ui": "vitest --ui",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "validate:registry": "node scripts/validate-registry.mjs --all"
   },
   "dependencies": {
     "@0xbeedao/mcp-taskwarrior": "1.0.0",

--- a/packages/art-and-culture/pictify.json
+++ b/packages/art-and-culture/pictify.json
@@ -1,12 +1,11 @@
 {
   "type": "mcp-server",
-  "packageName": "@pictify/mcp-server",
+  "packageName": "@toolsdk-remote/pictify",
   "description": "Render images, animated GIFs, and PDFs from HTML/CSS, live URLs, or reusable Handlebars/FabricJS templates. Batch up to 100 personalised renders per request and A/B test image variants with built-in experiments. Hosted remote at https://mcp.pictify.io or self-host via npx @pictify/mcp-server.",
   "url": "https://github.com/pictify-io/mcp",
   "runtime": "node",
   "license": "MIT",
   "name": "Pictify",
-  "key": "pictify",
   "author": "pictify-io",
   "logo": "https://pictify.io/logo.png",
   "env": {

--- a/packages/databases/supabase-mcp-server-supabase.json
+++ b/packages/databases/supabase-mcp-server-supabase.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Supabase MCP",
-  "packageName": "@supabase/mcp-server-supabase",
+  "packageName": "@toolsdk-remote/supabase-mcp-server-supabase",
   "description": "MCP server for interacting with the Supabase platform",
   "url": "https://github.com/supabase-community/supabase-mcp",
   "runtime": "node",

--- a/packages/developer-tools/github-mcp-server.json
+++ b/packages/developer-tools/github-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "github-mcp-server",
+  "packageName": "@toolsdk-remote/github-mcp-server",
   "description": "GitHub's official MCP Server",
   "url": "https://github.com/github/github-mcp-server",
   "runtime": "node",

--- a/packages/developer-tools/github-mcp.json
+++ b/packages/developer-tools/github-mcp.json
@@ -6,14 +6,5 @@
   "runtime": "node",
   "license": "mit",
   "env": {},
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "http://localhost:3001/mcp",
-      "auth": {
-        "type": "oauth2"
-      }
-    }
-  ],
   "name": "Local Remote GitHub MCP Server"
 }

--- a/packages/developer-tools/postman-postman-mcp-server.json
+++ b/packages/developer-tools/postman-postman-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "postman/postman-mcp-server",
+  "packageName": "@toolsdk-remote/postman-postman-mcp-server",
   "description": "A basic MCP server to operate on the Postman API.",
   "url": "https://github.com/postmanlabs/postman-mcp-server",
   "runtime": "node",

--- a/packages/developer-tools/sveltejs-mcp.json
+++ b/packages/developer-tools/sveltejs-mcp.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "@sveltejs/mcp",
+  "packageName": "@toolsdk-remote/sveltejs-mcp",
   "description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
   "url": "https://github.com/sveltejs/mcp",
   "runtime": "node",

--- a/packages/finance-fintech/inferventis.json
+++ b/packages/finance-fintech/inferventis.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Inferventis — Live Financial Data MCP",
-  "packageName": "@inferventis/mcp-server",
+  "packageName": "@toolsdk-remote/inferventis",
   "description": "Live financial data MCP for AI agents: real-time FX rates, stock quotes, crypto prices (10,000+ coins via CoinGecko), Open Banking (PSD2/TrueLayer, 300+ banks), Stripe payment data, and a financial calculator. Includes semantic tool_finder for agent discovery. Pay-per-call via x402 micropayments on Base ($0.001 USDC) — no API key required.",
   "url": "https://github.com/Bankee-ai/inferventis",
   "runtime": "node",

--- a/packages/finance-fintech/longbridge-mcp.json
+++ b/packages/finance-fintech/longbridge-mcp.json
@@ -1,12 +1,13 @@
 {
   "type": "mcp-server",
   "name": "Longbridge MCP",
-  "packageName": "com.longbridge/mcp",
+  "packageName": "@toolsdk-remote/longbridge-mcp",
   "packageVersion": "0.3.2",
   "description": "Official Longbridge brokerage MCP — 133 tools for US/HK/CN real-time quotes, options, trading, fundamentals, IPO, alerts, DCA & portfolio management. OAuth 2.1 RFC 9728.",
   "url": "https://github.com/longbridge/longbridge-mcp",
   "logo": "https://raw.githubusercontent.com/longbridge/longbridge-mcp/main/docs/logo.png",
   "license": "MIT",
+  "runtime": "node",
   "env": {},
   "remotes": [
     {

--- a/packages/finance-fintech/openregistry.json
+++ b/packages/finance-fintech/openregistry.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "OpenRegistry",
-  "packageName": "openregistry-mcp",
+  "packageName": "@toolsdk-remote/openregistry",
   "description": "Connects AI agents to live data from 30 official national company registries (UK Companies House, France RNE, Germany Handelsregister, Korea OpenDART, and more) for KYB, due diligence, and ownership chain walks. Returns the registry's own response unmodified.",
   "url": "https://github.com/sophymarine/openregistry",
   "runtime": "node",

--- a/packages/finance-fintech/proofbets.json
+++ b/packages/finance-fintech/proofbets.json
@@ -3,7 +3,7 @@
   "packageName": "proofbets",
   "description": "Query verified crypto casino data, bonus codes, prediction market fees, and World Cup 2026 odds",
   "url": "https://github.com/vjrmuc/proofbets/tree/main/mcp-server",
-  "homepage": "https://proofbets.com/developers/",
+  "readme": "https://proofbets.com/developers/",
   "runtime": "node",
   "license": "unknown",
   "env": {},

--- a/packages/marketing/hyper.json
+++ b/packages/marketing/hyper.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "hyperfx-ai/marketing-skills",
+  "packageName": "@toolsdk-remote/hyper",
   "description": "Connects AI agents to 200+ marketing integrations and tools, covering paid ads (Google Ads, Meta, TikTok, LinkedIn, Amazon, Pinterest), SEO and analytics (GA4, Search Console, Google Tag Manager, BigQuery), social publishing, ad-library and social scrapers, and image and video generation, with every action gated behind human-in-the-loop approval.",
   "url": "https://github.com/hyperfx-ai/marketing-skills",
   "runtime": "node",

--- a/packages/marketing/publora.json
+++ b/packages/marketing/publora.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "@publora/mcp-server",
+  "packageName": "@toolsdk-remote/publora",
   "name": "Publora",
   "description": "Schedule and publish social media posts across 10 platforms from AI agents. Create, list, update, and delete scheduled posts, request media upload URLs, list connected channels, and manage LinkedIn comments and reactions.",
   "url": "https://github.com/publora/mcp-server",

--- a/packages/marketing/tiktok-ads-mcp-server.json
+++ b/packages/marketing/tiktok-ads-mcp-server.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Ads MCP",
-  "packageName": "tiktok-ads-mcp-server",
+  "packageName": "@toolsdk-remote/tiktok-ads-mcp-server",
   "description": "TikTok Ads MCP Server – Model Context Protocol Server for TikTok Ads Marketing API Integration",
   "url": "https://github.com/AdsMCP/tiktok-ads-mcp-server",
   "runtime": "python",

--- a/packages/search-data-extraction/xquik.json
+++ b/packages/search-data-extraction/xquik.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "xquik",
+  "packageName": "@toolsdk-remote/xquik",
   "name": "Xquik X/Twitter Data Platform",
   "description": "X (Twitter) data platform for tweet search, profile tweets, follower export, media download, posting, DMs, webhooks, 100+ REST endpoints, 23 extraction types, and MCP tools.",
   "url": "https://github.com/Xquik-dev/x-twitter-scraper",

--- a/packages/travel-transportation/mycartracks.json
+++ b/packages/travel-transportation/mycartracks.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "MyCarTracks",
-  "packageName": "mycartracks-mcp",
+  "packageName": "@toolsdk-remote/mycartracks",
   "description": "Mainly app-based GPS vehicle tracking and automatic mileage tracking with MCP access to trip, track, and vehicle data.",
   "url": "https://mycartracks.com/resources/connect-with-ai",
   "readme": "https://mycartracks.com/resources/connect-with-ai",

--- a/packages/uncategorized/arch-tools-mcp.json
+++ b/packages/uncategorized/arch-tools-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Arch Tools",
-  "packageName": "arch-tools-mcp",
+  "packageName": "@toolsdk-remote/arch-tools-mcp",
   "description": "61 production AI tools — web scraping, crypto data, AI generation, sentiment analysis, OCR, TTS, and more. Pay per-call with USDC via x402 protocol or use API keys. The first API platform where AI agents pay with crypto.",
   "url": "https://github.com/Deesmo/Arch-AI-Tools",
   "runtime": "node",

--- a/packages/uncategorized/augments-mcp-server.json
+++ b/packages/uncategorized/augments-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "augments-mcp-server",
+  "packageName": "@toolsdk-remote/augments-mcp-server",
   "description": "Augments MCP Server - A comprehensive framework documentation provider for Claude Code",
   "url": "https://github.com/augmnt/augments-mcp-server",
   "runtime": "python",

--- a/packages/uncategorized/buywhere-mcp-server.json
+++ b/packages/uncategorized/buywhere-mcp-server.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "BuyWhere",
-  "packageName": "@buywhere/mcp-server",
+  "packageName": "@toolsdk-remote/buywhere-mcp-server",
   "description": "Real-time product search and price comparison for Singapore and Southeast Asia. Search 260K+ products from Lazada, Shopee, Courts, FairPrice, and other major SEA merchants. Get live prices, stock availability, and cross-merchant comparison in a single query.",
   "url": "https://github.com/BuyWhere/buywhere-mcp",
   "runtime": "node",

--- a/packages/uncategorized/buywhere.json
+++ b/packages/uncategorized/buywhere.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "BuyWhere",
-  "packageName": "@buywhere/mcp-server",
+  "packageName": "@toolsdk-remote/buywhere",
   "description": "Real-time product search and price-comparison MCP server. 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US. Exposes search_products, get_product, compare_products, find_best_price, get_deals, list_categories, find_similar.",
   "url": "https://github.com/BuyWhere/buywhere-mcp",
   "runtime": "node",

--- a/packages/uncategorized/iterationlayer.json
+++ b/packages/uncategorized/iterationlayer.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Iteration Layer",
-  "packageName": "iterationlayer",
+  "packageName": "@toolsdk-remote/iterationlayer",
   "description": "Document extraction, image transformation, programmatic image generation, document generation, and sheet generation via composable APIs.",
   "url": "https://github.com/iterationlayer/mcp",
   "runtime": "node",

--- a/packages/uncategorized/keboola-mcp-server.json
+++ b/packages/uncategorized/keboola-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "keboola-mcp-server",
+  "packageName": "@toolsdk-remote/keboola-mcp-server",
   "description": "Connect your AI assistants to Keboola and expose your data, transformations, SQL queries, ...",
   "url": "https://github.com/keboola/mcp-server",
   "runtime": "python",

--- a/packages/uncategorized/math-mcp-learning-server.json
+++ b/packages/uncategorized/math-mcp-learning-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "math-mcp-learning-server",
+  "packageName": "@toolsdk-remote/math-mcp-learning-server",
   "description": "Educational MCP server with 12 math/stats tools, visualizations, and persistent workspace",
   "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
   "runtime": "python",

--- a/packages/uncategorized/mia-platform-console-mcp-server.json
+++ b/packages/uncategorized/mia-platform-console-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "@mia-platform/console-mcp-server",
+  "packageName": "@toolsdk-remote/mia-platform-console-mcp-server",
   "description": "The official MCP Server from Mia-Platform to interact with Mia-Platform Console",
   "url": "https://github.com/mia-platform/console-mcp-server",
   "runtime": "node",

--- a/packages/uncategorized/packrift-mcp.json
+++ b/packages/uncategorized/packrift-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "Packrift MCP",
-  "packageName": "packrift-mcp",
+  "packageName": "@toolsdk-remote/packrift-mcp",
   "description": "Remote MCP server for Packrift's packaging-supplies catalog with product search, pricing, inventory, packaging recommendations, and checkout URLs.",
   "url": "https://github.com/Packrift/packrift-mcp",
   "readme": "https://github.com/Packrift/packrift-mcp#readme",

--- a/packages/uncategorized/qr-business-cards-mcp.json
+++ b/packages/uncategorized/qr-business-cards-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "name": "QR Business Cards",
-  "packageName": "qr-business-cards-mcp",
+  "packageName": "@toolsdk-remote/qr-business-cards-mcp",
   "description": "Create professional QR business cards via AI assistants. No API key required. Generate profiles with contact info, social links, and get printable QR-coded business cards delivered.",
   "url": "https://github.com/ajfrai/qr-business-cards-mcp",
   "runtime": "node",

--- a/packages/uncategorized/youdotcom-oss-mcp.json
+++ b/packages/uncategorized/youdotcom-oss-mcp.json
@@ -1,6 +1,6 @@
 {
   "type": "mcp-server",
-  "packageName": "@youdotcom-oss/mcp",
+  "packageName": "@toolsdk-remote/youdotcom-oss-mcp",
   "description": "Web search, AI agent, and content extraction via You.com APIs",
   "url": "https://github.com/youdotcom-oss/dx-toolkit",
   "runtime": "node",

--- a/scripts/lib/registry-validator.mjs
+++ b/scripts/lib/registry-validator.mjs
@@ -1,0 +1,512 @@
+import path from "node:path";
+
+export const REMOTE_PACKAGE_PREFIX = "@toolsdk-remote/";
+
+const RUNTIMES = new Set(["node", "python", "java", "go", "docker"]);
+const TOP_LEVEL_FIELDS = new Set([
+  "type",
+  "runtime",
+  "packageName",
+  "packageVersion",
+  "bin",
+  "binArgs",
+  "remotes",
+  "key",
+  "name",
+  "description",
+  "readme",
+  "url",
+  "license",
+  "logo",
+  "author",
+  "env",
+]);
+const OPTIONAL_STRING_FIELDS = [
+  "packageVersion",
+  "bin",
+  "key",
+  "name",
+  "description",
+  "readme",
+  "url",
+  "license",
+  "logo",
+  "author",
+];
+
+function issue(level, code, message, file, field) {
+  return { level, code, message, file, field };
+}
+
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function addUnknownFieldIssues(issues, value, allowedFields, file, fieldPrefix = "") {
+  for (const key of Object.keys(value)) {
+    if (!allowedFields.has(key)) {
+      const field = fieldPrefix ? `${fieldPrefix}.${key}` : key;
+      issues.push(issue("error", "UNKNOWN_FIELD", `Unknown field "${field}"`, file, field));
+    }
+  }
+}
+
+function isPrivateHostname(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized.endsWith(".localhost") || normalized === "::1") {
+    return true;
+  }
+
+  const ipv4 = normalized.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!ipv4) return false;
+
+  const first = Number(ipv4[1]);
+  const second = Number(ipv4[2]);
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function validateRemote(remote, index, file) {
+  const issues = [];
+  const field = `remotes.${index}`;
+  if (!isObject(remote)) {
+    return [issue("error", "INVALID_TYPE", `"${field}" must be an object`, file, field)];
+  }
+
+  addUnknownFieldIssues(issues, remote, new Set(["type", "url", "auth"]), file, field);
+  if (remote.type !== "streamable-http") {
+    issues.push(
+      issue(
+        "error",
+        "INVALID_REMOTE_TYPE",
+        `"${field}.type" must be "streamable-http"`,
+        file,
+        `${field}.type`,
+      ),
+    );
+  }
+
+  if (typeof remote.url !== "string" || remote.url.length === 0) {
+    issues.push(
+      issue(
+        "error",
+        "INVALID_TYPE",
+        `"${field}.url" must be a non-empty string`,
+        file,
+        `${field}.url`,
+      ),
+    );
+  } else {
+    try {
+      const url = new URL(remote.url);
+      if (url.protocol !== "https:") {
+        issues.push(
+          issue(
+            "error",
+            "REMOTE_HTTPS_REQUIRED",
+            "Remote MCP URLs must use HTTPS",
+            file,
+            `${field}.url`,
+          ),
+        );
+      }
+      if (isPrivateHostname(url.hostname)) {
+        issues.push(
+          issue(
+            "error",
+            "REMOTE_PRIVATE_HOST",
+            "Remote MCP URLs cannot target localhost or a private network",
+            file,
+            `${field}.url`,
+          ),
+        );
+      }
+    } catch {
+      issues.push(
+        issue("error", "INVALID_URL", `"${field}.url" must be a valid URL`, file, `${field}.url`),
+      );
+    }
+  }
+
+  if (remote.auth !== undefined) {
+    if (!isObject(remote.auth)) {
+      issues.push(
+        issue("error", "INVALID_TYPE", `"${field}.auth" must be an object`, file, `${field}.auth`),
+      );
+    } else {
+      addUnknownFieldIssues(
+        issues,
+        remote.auth,
+        new Set(["type", "scopes"]),
+        file,
+        `${field}.auth`,
+      );
+      if (remote.auth.type !== "oauth2") {
+        issues.push(
+          issue(
+            "error",
+            "INVALID_AUTH_TYPE",
+            `"${field}.auth.type" must be "oauth2"`,
+            file,
+            `${field}.auth.type`,
+          ),
+        );
+      }
+      if (
+        remote.auth.scopes !== undefined &&
+        (!Array.isArray(remote.auth.scopes) ||
+          remote.auth.scopes.some((scope) => typeof scope !== "string"))
+      ) {
+        issues.push(
+          issue(
+            "error",
+            "INVALID_TYPE",
+            `"${field}.auth.scopes" must be an array of strings`,
+            file,
+            `${field}.auth.scopes`,
+          ),
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function validatePackageConfig(value, file = "(unknown)") {
+  const issues = [];
+  if (!isObject(value)) {
+    return [issue("error", "INVALID_ROOT", "JSON root must be an object", file)];
+  }
+
+  addUnknownFieldIssues(issues, value, TOP_LEVEL_FIELDS, file);
+
+  if (value.type !== "mcp-server") {
+    issues.push(issue("error", "INVALID_TYPE", '"type" must be "mcp-server"', file, "type"));
+  }
+  if (!RUNTIMES.has(value.runtime)) {
+    issues.push(
+      issue(
+        "error",
+        "INVALID_RUNTIME",
+        `"runtime" must be one of: ${[...RUNTIMES].join(", ")}`,
+        file,
+        "runtime",
+      ),
+    );
+  }
+  if (typeof value.packageName !== "string" || value.packageName.trim().length === 0) {
+    issues.push(
+      issue(
+        "error",
+        "INVALID_PACKAGE_NAME",
+        '"packageName" must be a non-empty string',
+        file,
+        "packageName",
+      ),
+    );
+  }
+
+  for (const field of OPTIONAL_STRING_FIELDS) {
+    if (value[field] !== undefined && typeof value[field] !== "string") {
+      issues.push(issue("error", "INVALID_TYPE", `"${field}" must be a string`, file, field));
+    }
+  }
+
+  if (
+    value.binArgs !== undefined &&
+    (!Array.isArray(value.binArgs) || value.binArgs.some((arg) => typeof arg !== "string"))
+  ) {
+    issues.push(
+      issue("error", "INVALID_TYPE", '"binArgs" must be an array of strings', file, "binArgs"),
+    );
+  }
+
+  if (value.env !== undefined) {
+    if (!isObject(value.env)) {
+      issues.push(issue("error", "INVALID_TYPE", '"env" must be an object', file, "env"));
+    } else {
+      for (const [name, definition] of Object.entries(value.env)) {
+        const field = `env.${name}`;
+        if (!isObject(definition)) {
+          issues.push(issue("error", "INVALID_TYPE", `"${field}" must be an object`, file, field));
+          continue;
+        }
+        addUnknownFieldIssues(
+          issues,
+          definition,
+          new Set(["description", "required", "default", "secret"]),
+          file,
+          field,
+        );
+        if (typeof definition.description !== "string") {
+          issues.push(
+            issue(
+              "error",
+              "INVALID_TYPE",
+              `"${field}.description" must be a string`,
+              file,
+              `${field}.description`,
+            ),
+          );
+        }
+        if (typeof definition.required !== "boolean") {
+          issues.push(
+            issue(
+              "error",
+              "INVALID_TYPE",
+              `"${field}.required" must be a boolean`,
+              file,
+              `${field}.required`,
+            ),
+          );
+        }
+        if (definition.default !== undefined && typeof definition.default !== "string") {
+          issues.push(
+            issue(
+              "error",
+              "INVALID_TYPE",
+              `"${field}.default" must be a string`,
+              file,
+              `${field}.default`,
+            ),
+          );
+        }
+        if (definition.secret !== undefined && typeof definition.secret !== "boolean") {
+          issues.push(
+            issue(
+              "error",
+              "INVALID_TYPE",
+              `"${field}.secret" must be a boolean`,
+              file,
+              `${field}.secret`,
+            ),
+          );
+        }
+        if (definition.secret === true && definition.default !== undefined) {
+          issues.push(
+            issue(
+              "error",
+              "SECRET_DEFAULT_FORBIDDEN",
+              `"${field}" cannot declare a default value when secret is true`,
+              file,
+              field,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  const hasRemotes = Array.isArray(value.remotes) && value.remotes.length > 0;
+  const hasRemotePrefix =
+    typeof value.packageName === "string" && value.packageName.startsWith(REMOTE_PACKAGE_PREFIX);
+
+  if (value.remotes !== undefined && !Array.isArray(value.remotes)) {
+    issues.push(issue("error", "INVALID_TYPE", '"remotes" must be an array', file, "remotes"));
+  } else if (Array.isArray(value.remotes)) {
+    if (value.remotes.length === 0) {
+      issues.push(
+        issue(
+          "error",
+          "EMPTY_REMOTES",
+          '"remotes" must contain at least one endpoint',
+          file,
+          "remotes",
+        ),
+      );
+    }
+    value.remotes.forEach((remote, index) => {
+      issues.push(...validateRemote(remote, index, file));
+    });
+    const urls = value.remotes
+      .map((remote) => remote?.url)
+      .filter((url) => typeof url === "string");
+    if (new Set(urls).size !== urls.length) {
+      issues.push(
+        issue(
+          "error",
+          "DUPLICATE_REMOTE_URL",
+          "Remote URLs must be unique within a package",
+          file,
+          "remotes",
+        ),
+      );
+    }
+  }
+
+  if (hasRemotes && !hasRemotePrefix) {
+    issues.push(
+      issue(
+        "error",
+        "REMOTE_PACKAGE_PREFIX",
+        `Packages with remotes must use a packageName beginning with "${REMOTE_PACKAGE_PREFIX}"`,
+        file,
+        "packageName",
+      ),
+    );
+  }
+  if (hasRemotes && value.key !== undefined) {
+    issues.push(
+      issue(
+        "error",
+        "REMOTE_CUSTOM_KEY_FORBIDDEN",
+        "Remote MCP packages must use packageName as their registry key",
+        file,
+        "key",
+      ),
+    );
+  }
+  if (hasRemotePrefix && !hasRemotes) {
+    issues.push(
+      issue(
+        "error",
+        "REMOTE_ENDPOINT_REQUIRED",
+        `Packages beginning with "${REMOTE_PACKAGE_PREFIX}" must define remotes`,
+        file,
+        "remotes",
+      ),
+    );
+  }
+
+  return issues;
+}
+
+export function getPackageKey(config) {
+  return typeof config?.key === "string" && config.key.length > 0
+    ? config.key
+    : config?.packageName;
+}
+
+function groupPathsByKey(entries) {
+  const groups = new Map();
+  for (const [file, config] of entries) {
+    const key = getPackageKey(config);
+    if (typeof key !== "string" || key.length === 0) continue;
+    const paths = groups.get(key) ?? [];
+    paths.push(file);
+    groups.set(key, paths);
+  }
+  return groups;
+}
+
+function pairKey(key, left, right) {
+  return `${key}\0${[left, right].sort().join("\0")}`;
+}
+
+function collisionPairs(groups) {
+  const pairs = new Set();
+  for (const [key, paths] of groups) {
+    for (let left = 0; left < paths.length; left += 1) {
+      for (let right = left + 1; right < paths.length; right += 1) {
+        pairs.add(pairKey(key, paths[left], paths[right]));
+      }
+    }
+  }
+  return pairs;
+}
+
+export function validateKeyChanges(baseEntries, headEntries, changes) {
+  const issues = [];
+  const baseGroups = groupPathsByKey(baseEntries);
+  const headGroups = groupPathsByKey(headEntries);
+  const basePairs = collisionPairs(baseGroups);
+  const changedPaths = new Set(
+    changes.flatMap((change) => [change.path, change.oldPath]).filter(Boolean),
+  );
+
+  for (const [key, paths] of headGroups) {
+    if (paths.length < 2) continue;
+    for (let left = 0; left < paths.length; left += 1) {
+      for (let right = left + 1; right < paths.length; right += 1) {
+        const leftPath = paths[left];
+        const rightPath = paths[right];
+        if (
+          !basePairs.has(pairKey(key, leftPath, rightPath)) &&
+          (changedPaths.has(leftPath) || changedPaths.has(rightPath))
+        ) {
+          const file = changedPaths.has(leftPath) ? leftPath : rightPath;
+          issues.push(
+            issue(
+              "error",
+              "DUPLICATE_PACKAGE_KEY",
+              `Package key "${key}" conflicts with ${file === leftPath ? rightPath : leftPath}`,
+              file,
+              "key",
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  for (const change of changes) {
+    if (change.status !== "A") continue;
+    const config = headEntries.get(change.path);
+    const key = getPackageKey(config);
+    const existingPaths = baseGroups.get(key) ?? [];
+    if (existingPaths.length > 0) {
+      issues.push(
+        issue(
+          "error",
+          "EXISTING_KEY_REPLACEMENT",
+          `New file cannot reuse existing package key "${key}" from ${existingPaths.join(", ")}`,
+          change.path,
+          "key",
+        ),
+      );
+    }
+  }
+
+  for (const change of changes) {
+    if (change.status !== "M") continue;
+    const oldKey = getPackageKey(baseEntries.get(change.path));
+    const newKey = getPackageKey(headEntries.get(change.path));
+    if (oldKey && newKey && oldKey !== newKey) {
+      issues.push(
+        issue(
+          "warning",
+          "PACKAGE_KEY_CHANGED",
+          `Package key changed from "${oldKey}" to "${newKey}" and requires manual review`,
+          change.path,
+          "key",
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+export function validateNewPackagePath(file, categories) {
+  const issues = [];
+  const parts = file.split("/");
+  if (parts.length !== 3 || parts[0] !== "packages" || !categories.has(parts[1])) {
+    issues.push(
+      issue(
+        "error",
+        "INVALID_PACKAGE_PATH",
+        "New package files must be placed directly in a configured packages/<category> directory",
+        file,
+      ),
+    );
+  }
+
+  const filename = path.basename(file);
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*\.json$/.test(filename)) {
+    issues.push(
+      issue(
+        "error",
+        "INVALID_PACKAGE_FILENAME",
+        "New package filenames must use lowercase kebab-case",
+        file,
+      ),
+    );
+  }
+  return issues;
+}

--- a/scripts/lib/registry-validator.node-test.mjs
+++ b/scripts/lib/registry-validator.node-test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  validateKeyChanges,
+  validateNewPackagePath,
+  validatePackageConfig,
+} from "./registry-validator.mjs";
+
+function localConfig(overrides = {}) {
+  return {
+    type: "mcp-server",
+    runtime: "node",
+    packageName: "example-mcp",
+    ...overrides,
+  };
+}
+
+function remoteConfig(overrides = {}) {
+  return localConfig({
+    packageName: "@toolsdk-remote/example-mcp",
+    remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
+    ...overrides,
+  });
+}
+
+test("accepts valid local and remote package configs", () => {
+  assert.deepEqual(validatePackageConfig(localConfig(), "local.json"), []);
+  assert.deepEqual(validatePackageConfig(remoteConfig(), "remote.json"), []);
+});
+
+test("requires the ToolSDK prefix whenever remotes are present", () => {
+  const issues = validatePackageConfig(remoteConfig({ packageName: "example-mcp" }), "remote.json");
+  assert.ok(issues.some((item) => item.code === "REMOTE_PACKAGE_PREFIX"));
+});
+
+test("requires a remote endpoint for ToolSDK remote package names", () => {
+  const issues = validatePackageConfig(
+    localConfig({ packageName: "@toolsdk-remote/example-mcp" }),
+    "remote.json",
+  );
+  assert.ok(issues.some((item) => item.code === "REMOTE_ENDPOINT_REQUIRED"));
+});
+
+test("rejects custom registry keys for remote packages", () => {
+  const issues = validatePackageConfig(remoteConfig({ key: "legacy-package" }), "remote.json");
+  assert.ok(issues.some((item) => item.code === "REMOTE_CUSTOM_KEY_FORBIDDEN"));
+});
+
+test("rejects unknown fields and private remote URLs", () => {
+  const issues = validatePackageConfig(
+    remoteConfig({
+      unexpected: true,
+      remotes: [{ type: "streamable-http", url: "http://localhost:3000/mcp" }],
+    }),
+    "remote.json",
+  );
+  assert.ok(issues.some((item) => item.code === "UNKNOWN_FIELD"));
+  assert.ok(issues.some((item) => item.code === "REMOTE_HTTPS_REQUIRED"));
+  assert.ok(issues.some((item) => item.code === "REMOTE_PRIVATE_HOST"));
+});
+
+test("supports environment metadata but rejects defaults for secrets", () => {
+  const validIssues = validatePackageConfig(
+    localConfig({
+      env: {
+        LOG_LEVEL: { description: "Log level", required: false, default: "info" },
+        API_KEY: { description: "API key", required: true, secret: true },
+      },
+    }),
+    "local.json",
+  );
+  assert.deepEqual(validIssues, []);
+
+  const invalidIssues = validatePackageConfig(
+    localConfig({
+      env: {
+        API_KEY: { description: "API key", required: true, secret: true, default: "token" },
+      },
+    }),
+    "local.json",
+  );
+  assert.ok(invalidIssues.some((item) => item.code === "SECRET_DEFAULT_FORBIDDEN"));
+});
+
+test("rejects new key collisions but tolerates unchanged historical collisions", () => {
+  const baseEntries = new Map([
+    ["packages/a/first.json", localConfig({ packageName: "shared" })],
+    ["packages/b/second.json", localConfig({ packageName: "shared" })],
+  ]);
+  const unchangedHead = new Map(baseEntries);
+  assert.deepEqual(
+    validateKeyChanges(baseEntries, unchangedHead, [
+      { status: "M", path: "packages/a/first.json" },
+    ]).filter((item) => item.level === "error"),
+    [],
+  );
+
+  const addedHead = new Map(baseEntries);
+  addedHead.set("packages/c/third.json", localConfig({ packageName: "shared" }));
+  const issues = validateKeyChanges(baseEntries, addedHead, [
+    { status: "A", path: "packages/c/third.json" },
+  ]);
+  assert.ok(issues.some((item) => item.code === "DUPLICATE_PACKAGE_KEY"));
+  assert.ok(issues.some((item) => item.code === "EXISTING_KEY_REPLACEMENT"));
+});
+
+test("rejects moving an existing key into a newly added file", () => {
+  const oldPath = "packages/a/first.json";
+  const newPath = "packages/b/replacement.json";
+  const config = localConfig({ packageName: "existing" });
+  const baseEntries = new Map([[oldPath, config]]);
+  const headEntries = new Map([[newPath, config]]);
+  const issues = validateKeyChanges(baseEntries, headEntries, [
+    { status: "D", path: oldPath },
+    { status: "A", path: newPath },
+  ]);
+  assert.ok(issues.some((item) => item.code === "EXISTING_KEY_REPLACEMENT"));
+});
+
+test("allows updates to retain their key and warns when it changes", () => {
+  const file = "packages/a/first.json";
+  const baseEntries = new Map([[file, localConfig({ packageName: "first" })]]);
+  const retainedEntries = new Map([[file, localConfig({ packageName: "first", name: "First" })]]);
+  assert.deepEqual(
+    validateKeyChanges(baseEntries, retainedEntries, [{ status: "M", path: file }]),
+    [],
+  );
+
+  const changedEntries = new Map([[file, localConfig({ packageName: "renamed" })]]);
+  const issues = validateKeyChanges(baseEntries, changedEntries, [{ status: "M", path: file }]);
+  assert.ok(issues.some((item) => item.code === "PACKAGE_KEY_CHANGED"));
+});
+
+test("requires new files to use a configured category and kebab-case filename", () => {
+  const categories = new Set(["developer-tools"]);
+  assert.deepEqual(
+    validateNewPackagePath("packages/developer-tools/example-mcp.json", categories),
+    [],
+  );
+  assert.equal(
+    validateNewPackagePath("packages/unknown/Example_MCP.json", categories).filter(
+      (item) => item.level === "error",
+    ).length,
+    2,
+  );
+});

--- a/scripts/official-registry/processors/remote.ts
+++ b/scripts/official-registry/processors/remote.ts
@@ -102,38 +102,26 @@ async function discoverProtectedResourceMetadata(
 
 function determinePackageInfo(server: RegistryServer): { runtime: string; packageName: string } {
   let runtime = "node";
-  let packageName: string | null = null;
 
   if (server.packages && server.packages.length > 0) {
     const pkg = server.packages[0];
     // Note: RegistryPackage interface uses 'registryType' as string, but we check for specific values
     if (pkg.registryType === "pypi") {
       runtime = "python";
-      if (pkg.identifier) {
-        packageName = pkg.identifier.split(":")[0];
-      }
     } else if (pkg.registryType === "npm") {
       runtime = "node";
-      if (pkg.identifier) {
-        packageName =
-          pkg.identifier.split("@").slice(0, -1).join("@") || pkg.identifier.split("@")[1];
-      }
     }
   }
 
-  if (!packageName && server.name) {
-    const namePart = server.name
-      .toLowerCase()
-      .replace(/[/.\s]+/g, "-")
-      .replace(/[^a-z0-9-]/g, "")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "");
-    packageName = `@toolsdk-remote/${namePart}`;
-  }
-
+  const namePart = server.name
+    .toLowerCase()
+    .replace(/[/.\s]+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
   return {
     runtime,
-    packageName: packageName || "unknown",
+    packageName: `@toolsdk-remote/${namePart || "unknown"}`,
   };
 }
 

--- a/scripts/validate-package.ts
+++ b/scripts/validate-package.ts
@@ -26,6 +26,7 @@ import {
   MCPServerPackageConfigSchema,
   withTimeout,
 } from "../src/shared/scripts-helpers";
+import { validatePackageConfig } from "./lib/registry-validator.mjs";
 
 // ── CLI args ──────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
@@ -111,7 +112,7 @@ try {
 
 // Basic structural check before Zod
 if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-  fail("JSON root must be an object, got " + (Array.isArray(raw) ? "array" : typeof raw));
+  fail(`JSON root must be an object, got ${Array.isArray(raw) ? "array" : typeof raw}`);
 }
 
 console.log("✅ Valid JSON");
@@ -137,6 +138,18 @@ try {
   }
   fail("Schema validation failed", (e as Error).message);
 }
+
+const semanticIssues = validatePackageConfig(raw, filePath).filter(
+  (issue) => issue.level === "error",
+);
+if (semanticIssues.length > 0) {
+  console.error("\n❌ Registry policy validation failed:\n");
+  for (const issue of semanticIssues) {
+    console.error(`  • [${issue.code}] ${issue.message}`);
+  }
+  process.exit(1);
+}
+console.log("✅ Registry policy validation passed");
 
 // ── Step 3: Print summary ─────────────────────────────────────────────
 console.log("");

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import categories from "../config/categories.mjs";
+import {
+  validateKeyChanges,
+  validateNewPackagePath,
+  validatePackageConfig,
+} from "./lib/registry-validator.mjs";
+
+const defaultRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+let rootDir = defaultRootDir;
+
+function parseArgs(argv) {
+  const options = { all: false, base: undefined, format: "text", root: defaultRootDir };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--all") options.all = true;
+    else if (arg === "--base") options.base = argv[++index];
+    else if (arg === "--format") options.format = argv[++index];
+    else if (arg === "--root") options.root = argv[++index];
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.all && !options.base) {
+    throw new Error("Use --all or provide --base <git-ref>");
+  }
+  if (!new Set(["text", "github", "json"]).has(options.format)) {
+    throw new Error("--format must be one of: text, github, json");
+  }
+  return options;
+}
+
+function git(args, encoding = "utf8") {
+  return execFileSync("git", args, { cwd: rootDir, encoding, maxBuffer: 64 * 1024 * 1024 });
+}
+
+function listWorkingTreePackageFiles() {
+  const files = [];
+  const packagesDir = path.join(rootDir, "packages");
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolutePath);
+      else if (entry.isFile() && entry.name.endsWith(".json")) {
+        files.push(path.relative(rootDir, absolutePath).split(path.sep).join("/"));
+      }
+    }
+  };
+  visit(packagesDir);
+  return files.sort();
+}
+
+function parseConfig(content, file, issues) {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    issues.push({
+      level: "error",
+      code: "INVALID_JSON",
+      message: error instanceof Error ? error.message : String(error),
+      file,
+    });
+    return undefined;
+  }
+}
+
+function loadWorkingTreeEntries(issues) {
+  const entries = new Map();
+  for (const file of listWorkingTreePackageFiles()) {
+    const config = parseConfig(fs.readFileSync(path.join(rootDir, file), "utf8"), file, issues);
+    if (config !== undefined) entries.set(file, config);
+  }
+  return entries;
+}
+
+function parseChanges(base) {
+  const mergeBase = git(["merge-base", base, "HEAD"]).trim();
+  const output = git([
+    "diff",
+    "--name-status",
+    "-z",
+    "--find-renames",
+    mergeBase,
+    "--",
+    "packages",
+  ]);
+  const tokens = output.split("\0");
+  const changes = [];
+  for (let index = 0; index < tokens.length && tokens[index]; ) {
+    const statusToken = tokens[index++];
+    const status = statusToken[0];
+    if (status === "R" || status === "C") {
+      changes.push({ status: "R", oldPath: tokens[index++], path: tokens[index++] });
+    } else {
+      changes.push({ status, path: tokens[index++] });
+    }
+  }
+  return { changes, mergeBase };
+}
+
+function reconstructBaseEntries(headEntries, changes, mergeBase, issues) {
+  const entries = new Map(headEntries);
+  for (const change of changes) {
+    if (change.status === "A") {
+      entries.delete(change.path);
+      continue;
+    }
+
+    if (change.status === "R") entries.delete(change.path);
+    const basePath = change.oldPath ?? change.path;
+    if (!basePath.endsWith(".json")) continue;
+    try {
+      const content = git(["show", `${mergeBase}:${basePath}`]);
+      const config = parseConfig(content, basePath, issues);
+      if (config !== undefined) entries.set(basePath, config);
+    } catch (error) {
+      issues.push({
+        level: "error",
+        code: "BASE_FILE_READ_FAILED",
+        message: `Could not read ${basePath} from ${mergeBase}: ${error.message}`,
+        file: basePath,
+      });
+    }
+  }
+  return entries;
+}
+
+function escapeWorkflowCommand(value) {
+  return String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+function printIssues(issues, format) {
+  if (format === "json") {
+    console.log(JSON.stringify(issues, null, 2));
+    return;
+  }
+
+  for (const item of issues) {
+    if (format === "github") {
+      const command = item.level === "error" ? "error" : "warning";
+      const properties = [`title=${escapeWorkflowCommand(item.code)}`];
+      if (item.file) properties.unshift(`file=${escapeWorkflowCommand(item.file)}`, "line=1");
+      console.log(`::${command} ${properties.join(",")}::${escapeWorkflowCommand(item.message)}`);
+    } else {
+      console.log(`${item.level.toUpperCase()} [${item.code}] ${item.file ?? ""}: ${item.message}`);
+    }
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  rootDir = path.resolve(options.root);
+  const issues = [];
+  const headEntries = loadWorkingTreeEntries(issues);
+  const changedJsonPaths = new Set();
+
+  if (options.all) {
+    for (const [file, config] of headEntries) {
+      issues.push(...validatePackageConfig(config, file));
+    }
+  } else {
+    const { changes, mergeBase } = parseChanges(options.base);
+    for (const change of changes) {
+      if (change.path.endsWith(".json") && change.status !== "D") changedJsonPaths.add(change.path);
+    }
+
+    for (const file of changedJsonPaths) {
+      const config = headEntries.get(file);
+      if (config === undefined) {
+        issues.push({
+          level: "error",
+          code: "PACKAGE_FILE_NOT_FOUND",
+          message: "Changed package JSON file was not found in the working tree",
+          file,
+        });
+      } else {
+        issues.push(...validatePackageConfig(config, file));
+      }
+    }
+
+    const baseEntries = reconstructBaseEntries(headEntries, changes, mergeBase, issues);
+    const jsonChanges = changes.filter(
+      (change) => change.path.endsWith(".json") || change.oldPath?.endsWith(".json"),
+    );
+    issues.push(...validateKeyChanges(baseEntries, headEntries, jsonChanges));
+
+    const categoryKeys = new Set(categories.map((category) => category.key));
+    for (const change of jsonChanges) {
+      if (change.status === "A") {
+        issues.push(...validateNewPackagePath(change.path, categoryKeys));
+      }
+    }
+  }
+
+  printIssues(issues, options.format);
+  const errors = issues.filter((item) => item.level === "error").length;
+  const warnings = issues.length - errors;
+  if (options.format !== "json") {
+    console.log(
+      `Registry validation checked ${options.all ? headEntries.size : changedJsonPaths.size} file(s): ${errors} error(s), ${warnings} warning(s).`,
+    );
+  }
+  if (errors > 0) process.exitCode = 1;
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/src/shared/schemas/common-schema.ts
+++ b/src/shared/schemas/common-schema.ts
@@ -60,18 +60,22 @@ export const MCPServerPackageConfigSchema = z
 
     remotes: z
       .array(
-        z.object({
-          type: z.literal("streamable-http"),
-          url: z.string().url(),
-          auth: z
-            .object({
-              type: z.enum(["oauth2"]),
-              scopes: z.array(z.string()).optional(),
-            })
-            .optional()
-            .describe("OAuth 2.1 authentication configuration for MCP Server"),
-        }),
+        z
+          .object({
+            type: z.literal("streamable-http"),
+            url: z.string().url(),
+            auth: z
+              .object({
+                type: z.enum(["oauth2"]),
+                scopes: z.array(z.string()).optional(),
+              })
+              .strict()
+              .optional()
+              .describe("OAuth 2.1 authentication configuration for MCP Server"),
+          })
+          .strict(),
       )
+      .min(1)
       .optional(),
 
     // if no custom key then would use name
@@ -97,13 +101,21 @@ export const MCPServerPackageConfigSchema = z
     author: z.string().optional().describe("Author name of the ToolSDK.ai's developer ID"),
     env: z
       .record(
-        z.object({
-          description: z.string(),
-          required: z.boolean(),
-        }),
+        z
+          .object({
+            description: z.string(),
+            required: z.boolean(),
+            default: z.string().optional(),
+            secret: z.boolean().optional(),
+          })
+          .strict()
+          .refine((definition) => definition.secret !== true || definition.default === undefined, {
+            message: "Secret environment variables cannot define default values",
+          }),
       )
       .optional(),
   })
+  .strict()
   .openapi("MCPServerPackageConfig");
 
 export const PackageConfigSchema = z


### PR DESCRIPTION
## Summary

- add a dependency-free validator for strict package schemas, remote identity rules, URL safety, file placement, and incremental key collisions
- use `@toolsdk-remote/*` as the canonical registry identity for remote MCP servers and migrate existing remote entries
- replace dependency installation in pull request validation with Node-only deterministic checks
- document the Agent review flow and require explicit, commit-bound approval before squash merging

## Remote identity behavior

The build path indexes entries by `key || packageName`, excludes `@toolsdk-remote/*` from npm dependencies, and selects configured remotes before local package execution. Remote entries therefore cannot define a custom `key`; their prefixed `packageName` is both the registry/gateway identity and the forwarding marker.

Generated indexes are intentionally unchanged. The existing publish workflow regenerates them with `make build` after changes reach `main`.

## Validation

- `node --test scripts/lib/registry-validator.node-test.mjs`
- `node scripts/validate-registry.mjs --all` (4,862 package files, 0 errors, 0 warnings)
- `node scripts/validate-registry.mjs --base origin/main --format text` (0 errors; 24 expected remote identity-change warnings)
- scoped Biome formatting and checks for all changed files
- `git diff --check origin/main...HEAD`

`make build` was not run because it installs dependencies and executes registered MCP packages.