### PR TITLE
Fix registry validation against the latest base

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:package": "vitest run src/domains/package",
-    "test:registry-validator": "node --test scripts/lib/registry-validator.node-test.mjs",
+    "test:registry-validator": "node --test scripts/lib/registry-validator.node-test.mjs scripts/validate-registry.node-test.mjs",
     "test:ui": "vitest --ui",
     "test:watch": "vitest watch",
     "validate:registry": "node scripts/validate-registry.mjs --all"

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -33,8 +33,13 @@ function parseArgs(argv) {
   return options;
 }
 
-function git(args, encoding = "utf8") {
-  return execFileSync("git", args, { cwd: rootDir, encoding, maxBuffer: 64 * 1024 * 1024 });
+function git(args, encoding = "utf8", input) {
+  return execFileSync("git", args, {
+    cwd: rootDir,
+    encoding,
+    input,
+    maxBuffer: 64 * 1024 * 1024,
+  });
 }
 
 function listWorkingTreePackageFiles() {
@@ -76,14 +81,65 @@ function loadWorkingTreeEntries(issues) {
   return entries;
 }
 
-function parseChanges(base) {
-  const mergeBase = git(["merge-base", base, "HEAD"]).trim();
+function loadRefEntries(ref, issues) {
+  const output = git(["ls-tree", "-r", "--name-only", "-z", ref, "--", "packages"]);
+  const files = output.split("\0").filter((file) => file.endsWith(".json"));
+  const entries = new Map();
+  if (files.length === 0) return entries;
+
+  const requests = files.map((file) => `${ref}:${file}\n`).join("");
+  const objects = git(["cat-file", "--batch"], null, requests);
+  let offset = 0;
+
+  for (const file of files) {
+    const headerEnd = objects.indexOf(0x0a, offset);
+    const header = objects.subarray(offset, headerEnd).toString("utf8");
+    const match = header.match(/^[0-9a-f]+ blob (\d+)$/);
+    if (!match) {
+      issues.push({
+        level: "error",
+        code: "BASE_FILE_READ_FAILED",
+        message: `Could not read ${file} from ${ref}: ${header}`,
+        file,
+      });
+      offset = headerEnd + 1;
+      continue;
+    }
+
+    const size = Number(match[1]);
+    const contentStart = headerEnd + 1;
+    const contentEnd = contentStart + size;
+    const config = parseConfig(
+      objects.subarray(contentStart, contentEnd).toString("utf8"),
+      file,
+      issues,
+    );
+    if (config !== undefined) entries.set(file, config);
+    offset = contentEnd + 1;
+  }
+
+  return entries;
+}
+
+function resolveComparison(base) {
+  const isActionsPullRequestMerge =
+    process.env.GITHUB_ACTIONS === "true" &&
+    /^refs\/pull\/\d+\/merge$/.test(process.env.GITHUB_REF ?? "");
+  if (isActionsPullRequestMerge) {
+    return { base: "HEAD^1", head: "HEAD^2" };
+  }
+  return { base, head: "HEAD" };
+}
+
+function parseChanges(base, head) {
+  const mergeBase = git(["merge-base", base, head]).trim();
   const output = git([
     "diff",
     "--name-status",
     "-z",
     "--find-renames",
     mergeBase,
+    head,
     "--",
     "packages",
   ]);
@@ -101,29 +157,17 @@ function parseChanges(base) {
   return { changes, mergeBase };
 }
 
-function reconstructBaseEntries(headEntries, changes, mergeBase, issues) {
-  const entries = new Map(headEntries);
+function applyChanges(baseEntries, headEntries, changes) {
+  const entries = new Map(baseEntries);
   for (const change of changes) {
-    if (change.status === "A") {
+    if (change.status === "D") {
       entries.delete(change.path);
       continue;
     }
 
-    if (change.status === "R") entries.delete(change.path);
-    const basePath = change.oldPath ?? change.path;
-    if (!basePath.endsWith(".json")) continue;
-    try {
-      const content = git(["show", `${mergeBase}:${basePath}`]);
-      const config = parseConfig(content, basePath, issues);
-      if (config !== undefined) entries.set(basePath, config);
-    } catch (error) {
-      issues.push({
-        level: "error",
-        code: "BASE_FILE_READ_FAILED",
-        message: `Could not read ${basePath} from ${mergeBase}: ${error.message}`,
-        file: basePath,
-      });
-    }
+    if (change.status === "R") entries.delete(change.oldPath);
+    const config = headEntries.get(change.path);
+    if (config !== undefined) entries.set(change.path, config);
   }
   return entries;
 }
@@ -162,7 +206,8 @@ function main() {
       issues.push(...validatePackageConfig(config, file));
     }
   } else {
-    const { changes, mergeBase } = parseChanges(options.base);
+    const comparison = resolveComparison(options.base);
+    const { changes } = parseChanges(comparison.base, comparison.head);
     for (const change of changes) {
       if (change.path.endsWith(".json") && change.status !== "D") changedJsonPaths.add(change.path);
     }
@@ -181,11 +226,12 @@ function main() {
       }
     }
 
-    const baseEntries = reconstructBaseEntries(headEntries, changes, mergeBase, issues);
+    const baseEntries = loadRefEntries(comparison.base, issues);
+    const proposedEntries = applyChanges(baseEntries, headEntries, changes);
     const jsonChanges = changes.filter(
       (change) => change.path.endsWith(".json") || change.oldPath?.endsWith(".json"),
     );
-    issues.push(...validateKeyChanges(baseEntries, headEntries, jsonChanges));
+    issues.push(...validateKeyChanges(baseEntries, proposedEntries, jsonChanges));
 
     const categoryKeys = new Set(categories.map((category) => category.key));
     for (const change of jsonChanges) {

--- a/scripts/validate-registry.node-test.mjs
+++ b/scripts/validate-registry.node-test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const validator = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "validate-registry.mjs",
+);
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" });
+}
+
+function writeConfig(root, filename, packageName) {
+  const file = path.join(root, "packages", "developer-tools", filename);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    `${JSON.stringify({ type: "mcp-server", runtime: "node", packageName }, null, 2)}\n`,
+  );
+}
+
+function runValidator(root, base, env = {}) {
+  return execFileSync(process.execPath, [validator, "--root", root, "--base", base], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function assertKeyCollision(run) {
+  let output = "";
+  assert.throws(run, (error) => {
+    output = `${error.stdout}${error.stderr}`;
+    return error.status === 1;
+  });
+  assert.match(output, /DUPLICATE_PACKAGE_KEY/);
+  assert.match(output, /EXISTING_KEY_REPLACEMENT/);
+}
+
+test("checks new keys against the latest base ref instead of the merge base", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "registry-validator-"));
+  try {
+    git(root, ["init", "-b", "main"]);
+    git(root, ["config", "user.name", "Registry Validator Test"]);
+    git(root, ["config", "user.email", "registry-validator@example.com"]);
+
+    writeConfig(root, "initial.json", "initial-package");
+    git(root, ["add", "."]);
+    git(root, ["commit", "-m", "Initial registry"]);
+    git(root, ["branch", "contributor"]);
+
+    writeConfig(root, "added-on-main.json", "shared-package");
+    git(root, ["add", "."]);
+    git(root, ["commit", "-m", "Add package on main"]);
+
+    git(root, ["switch", "--quiet", "contributor"]);
+    writeConfig(root, "contribution.json", "shared-package");
+    git(root, ["add", "."]);
+    git(root, ["commit", "-m", "Add conflicting contribution"]);
+
+    assertKeyCollision(() => runValidator(root, "main"));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("uses the current base parent for GitHub pull request merge refs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "registry-validator-"));
+  try {
+    git(root, ["init", "-b", "main"]);
+    git(root, ["config", "user.name", "Registry Validator Test"]);
+    git(root, ["config", "user.email", "registry-validator@example.com"]);
+
+    writeConfig(root, "initial.json", "initial-package");
+    git(root, ["add", "."]);
+    git(root, ["commit", "-m", "Initial registry"]);
+    const staleBase = git(root, ["rev-parse", "HEAD"]).trim();
+    git(root, ["branch", "contributor"]);
+
+    writeConfig(root, "added-on-main.json", "shared-package");
+    git(root, ["add", "."]);
+    git(root, ["commit", "-m", "Add package on main"]);
+
+    git(root, ["switch", "--quiet", "contributor"]);
+    writeConfig(root, "contribution.json", "shared-package");
+    git(root, ["add", "."]);
+    git(root, ["commit", "-m", "Add conflicting contribution"]);
+
+    git(root, ["switch", "--quiet", "main"]);
+    git(root, ["merge", "--no-ff", "contributor", "-m", "Synthetic pull request merge"]);
+
+    assertKeyCollision(() =>
+      runValidator(root, staleBase, {
+        GITHUB_ACTIONS: "true",
+        GITHUB_REF: "refs/pull/123/merge",
+      }),
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- load registry entries from the exact current base instead of reconstructing them from a pull request merge base
- apply contributor package changes on top of that base snapshot for key validation
- recognize GitHub Actions synthetic pull request merge refs and use their current-base and contributor-head parents, avoiding stale webhook base SHAs
- add regression tests for both old contributor branches and synthetic pull request merge refs

## Validation

- `node --test scripts/lib/registry-validator.node-test.mjs scripts/validate-registry.node-test.mjs`
- `node scripts/validate-registry.mjs --all`
- changed-file Biome check
- verified against PR #360, which is correctly rejected as reusing a key already present on current main