### PR TITLE
Add WealthVille MCP server (DeFi LP pool scoring, Solana + EVM)

### DIFF
--- a/packages/finance-fintech/wealthville.json
+++ b/packages/finance-fintech/wealthville.json
@@ -1,8 +1,8 @@
 {
   "type": "mcp-server",
   "name": "WealthVille",
-  "packageName": "@wealthville/mcp-server",
-  "description": "DeFi liquidity-pool scoring and signals. Ranks ~68,800 Solana LP pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) plus 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC, returning a 0-100 pool score and an ENTER/HOLD/EXIT/REDUCE/AVOID verdict with per-protocol calibrated confidence. Publishes a miss-inclusive 30-day track record.",
+  "packageName": "@toolsdk-remote/wealthville",
+  "description": "DeFi liquidity-pool scoring and signals. Ranks ~68,800 Solana LP pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) plus 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC, returning a 0-100 pool score and an ENTER/HOLD/EXIT/REDUCE/AVOID verdict with per-protocol calibrated confidence. Publishes a miss-inclusive 30-day track record. Also available as a local stdio server via the npm package @wealthville/mcp-server.",
   "url": "https://github.com/amitesh-m/wealthville-integrations",
   "runtime": "node",
   "license": "MIT",

--- a/packages/finance-fintech/wealthville.json
+++ b/packages/finance-fintech/wealthville.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "WealthVille",
+  "packageName": "@wealthville/mcp-server",
+  "description": "DeFi liquidity-pool scoring and signals. Ranks ~68,800 Solana LP pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) plus 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC, returning a 0-100 pool score and an ENTER/HOLD/EXIT/REDUCE/AVOID verdict with per-protocol calibrated confidence. Publishes a miss-inclusive 30-day track record.",
+  "url": "https://github.com/amitesh-m/wealthville-integrations",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://wealthville.net/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `packages/finance-fintech/wealthville.json`.

**WealthVille** scores DeFi liquidity pools and publishes the resulting signals:

- **Coverage** — ~68,800 Solana LP pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) and 575 EVM pools across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC.
- **Output** — a 0-100 pool score plus an ENTER / HOLD / EXIT / REDUCE / AVOID verdict, with confidence calibrated per protocol rather than pooled.
- **Track record** — a public, miss-inclusive 30-day endpoint (ENTER hit rate 0.63 across 3,043 resolved calls). Misses are published alongside hits.

Declared as a **remote** server: the hosted Streamable HTTP endpoint at `https://wealthville.net/mcp` needs no auth and no API key, so `env` is empty and no `auth` block is set. `npx -y @wealthville/mcp-server` also works for a local stdio install.

Source is MIT at [amitesh-m/wealthville-integrations](https://github.com/amitesh-m/wealthville-integrations); the package is on npm and in the official MCP registry.

I couldn't run `make validate` (no `bun` in my environment), so I checked the file against `common-schema.ts` by hand instead: no unknown fields, required keys present, `runtime` in the allowed enum, and the `remotes` entry matches the strict shape (`type: "streamable-http"` + `url`, `auth` omitted as optional). Happy to adjust if CI disagrees, or to move it to `packages/uncategorized` if you'd rather let the categoriser place it.