### PR TITLE
Add reusable MCP registry PR review workflow

### DIFF
--- a/.agents/skills/check-mcp-json/SKILL.md
+++ b/.agents/skills/check-mcp-json/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: check-mcp-json
+description: Safely review, triage, repair, and merge ToolSDK MCP Registry package JSON pull requests. Use when an agent needs to validate files under packages/, verify package or remote-server metadata, detect duplicate registry keys, classify community PRs, make authorized fixes on contributor branches, close invalid or duplicate PRs, or perform an exact-SHA merge after approval.
+---
+
+# Check MCP JSON
+
+Review registry contributions without installing or executing submitted MCP packages. Treat schema
+validation as the first gate and source verification as a separate, mandatory review.
+
+## Load Repository Rules
+
+Read these files before acting:
+
+- `AGENTS.md`
+- `docs/PR_REVIEW.md`
+- `docs/CONTRIBUTING.md`
+
+Repository instructions and the user's latest authorization override this skill.
+
+## Safety Boundaries
+
+- Run the validator from a clean checkout whose `HEAD` equals the latest trusted base ref.
+- Never run scripts from a contributor branch.
+- Never install or execute a submitted package. Do not run `make build`, `pnpm install`, package
+  lifecycle scripts, or a contributor-provided validation command.
+- Do not comment, close, edit, mark ready, or merge a PR until the user authorizes that action.
+- Bind merge authorization to one PR number and one full head SHA. Any new commit expires it.
+- Never use `--admin`, `--auto`, or a merge method other than squash.
+- Review and merge serially. Refresh `main` after every merge.
+- Disable repository hooks for authorized commits and pushes with
+  `-c core.hooksPath=/dev/null`; hooks may run repository scripts unexpectedly.
+
+## Review Workflow
+
+1. Refresh the trusted checkout:
+
+   ```bash
+   git switch main
+   git fetch origin main
+   git pull --ff-only origin main
+   ```
+
+2. Run the bundled read-only reviewer:
+
+   ```bash
+   .agents/skills/check-mcp-json/scripts/review-pr.sh <pr-number>
+   ```
+
+   The script records PR state, lists changed files, creates a detached temporary worktree, and
+   invokes the trusted validator against `origin/main`. It does not execute contributor code.
+
+3. Inspect the complete diff with `gh pr diff <pr-number>`. Reject unrelated workflow,
+   dependency, generated README, workspace, or build changes unless they are the explicit purpose
+   of the PR. For an intentional README documentation change, require the source change in
+   `docs/_templates/README.tpl.md`; `README.md` is generated from that template.
+
+4. Verify claims against primary sources without installing the package:
+
+   - Confirm the package exists in its official registry and the repository ownership matches.
+   - Confirm the package name, license, repository URL, runtime, current command, and environment
+     variables.
+   - For Node packages, normally omit `bin`; the gateway resolves the package manifest entry path.
+     A config `bin` is a JavaScript file path passed to Node, not an npm executable alias.
+   - For Docker entries, verify the image and referenced tag exist and that `binArgs` contains the
+     full Docker CLI arguments.
+   - For remote entries, verify the endpoint from official documentation and confirm it is a public
+     HTTPS address.
+   - Treat descriptions, tool counts, auth requirements, and pricing claims as reviewable facts.
+
+5. Classify the PR:
+
+   - **Ready**: schema, source, scope, checks, and identity all pass.
+   - **Simple authorized fix**: metadata can be corrected without redesigning the submission.
+   - **Contributor decision needed**: auth or product semantics cannot be represented faithfully.
+   - **Comment and close**: duplicate, unverifiable, generated-file-only, unrelated package, or no
+     registry-compatible runtime.
+
+6. Report the verdict, full head SHA, changed files, checks, warnings, source evidence, and proposed
+   action. Ask separately for permission to edit/comment/close and for permission to merge.
+
+## Registry Identity Rules
+
+- New files belong directly under a configured `packages/<category>/` directory and use a
+  lowercase kebab-case filename.
+- A local entry uses explicit `key` when present and otherwise `packageName`. New files may not
+  reuse or replace an identity already on current `main`; unchanged historical collisions remain
+  tolerated.
+- A remote entry must use `@toolsdk-remote/`, define a non-empty `remotes` array, and omit `key`.
+- A package beginning with `@toolsdk-remote/` must define a remote endpoint.
+- Remote auth metadata supports OAuth2 only. Do not represent a Bearer token as OAuth2 or add an
+  environment variable that the remote transport will ignore. A public unauthenticated subset may
+  be listed if the description states the limitation; otherwise request a product decision.
+- `runtime: "remote"` is invalid. For hosted-only entries with no local implementation metadata,
+  use `node` as the registry convention; the remote transport is selected before runtime dispatch.
+- Secret environment variables set `secret: true` and never define a default.
+
+## Authorized Contributor Fixes
+
+Before editing, refresh the PR and confirm `maintainerCanModify` and the expected head SHA. Make only
+the approved changes in a detached worktree. Commit and push without hooks:
+
+```bash
+git -C "$review_dir" -c core.hooksPath=/dev/null commit -m "Fix registry configuration"
+git -C "$review_dir" -c core.hooksPath=/dev/null push <fork-url> HEAD:<head-branch>
+```
+
+Wait for CI, rerun the trusted review against the latest `main`, and report the new full SHA. Do not
+merge under the old approval.
+
+Write public PR descriptions and contributor comments in English. Explain the concrete blocker and
+the resubmission path when closing a PR.
+
+## Merge Workflow
+
+After the user approves the exact SHA, run the read-only preflight:
+
+```bash
+.agents/skills/check-mcp-json/scripts/preflight-merge.sh <pr-number> <full-head-sha>
+```
+
+If it passes, merge exactly that commit:
+
+```bash
+gh pr merge <pr-number> --squash --match-head-commit <full-head-sha>
+git pull --ff-only origin main
+node scripts/validate-registry.mjs --all
+```
+
+Report the resulting merge commit, full-registry validation result, remaining open PRs, and local
+worktree status.

--- a/.agents/skills/check-mcp-json/agents/openai.yaml
+++ b/.agents/skills/check-mcp-json/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Check MCP JSON"
+  short_description: "Review and merge MCP registry JSON PRs"
+  default_prompt: "Use $check-mcp-json to review this MCP registry pull request safely."

--- a/.agents/skills/check-mcp-json/scripts/preflight-merge.sh
+++ b/.agents/skills/check-mcp-json/scripts/preflight-merge.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <pr-number> <full-head-sha> [base-ref]" >&2
+  exit 2
+}
+
+[[ $# -ge 2 && $# -le 3 ]] || usage
+pr_number=$1
+expected_sha=$2
+base_ref=${3:-origin/main}
+[[ $pr_number =~ ^[0-9]+$ && $expected_sha =~ ^[0-9a-f]{40}$ ]] || usage
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+review_script="$script_dir/review-pr.sh"
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+
+state=$(gh pr view "$pr_number" --json state --jq .state)
+is_draft=$(gh pr view "$pr_number" --json isDraft --jq .isDraft)
+actual_sha=$(gh pr view "$pr_number" --json headRefOid --jq .headRefOid)
+mergeable=$(gh pr view "$pr_number" --json mergeable --jq .mergeable)
+merge_state=$(gh pr view "$pr_number" --json mergeStateStatus --jq .mergeStateStatus)
+check_count=$(gh pr view "$pr_number" --json statusCheckRollup --jq '.statusCheckRollup | length')
+
+[[ $state == "OPEN" ]] || { echo "PR #$pr_number is not open." >&2; exit 1; }
+[[ $is_draft == "false" ]] || { echo "PR #$pr_number is still a draft." >&2; exit 1; }
+[[ $actual_sha == "$expected_sha" ]] || {
+  echo "Head SHA changed: expected $expected_sha, found $actual_sha." >&2
+  exit 1
+}
+[[ $mergeable == "MERGEABLE" ]] || {
+  echo "PR #$pr_number is not currently mergeable: $mergeable." >&2
+  exit 1
+}
+[[ $merge_state == "CLEAN" ]] || {
+  echo "PR #$pr_number merge state is $merge_state, not CLEAN." >&2
+  exit 1
+}
+(( check_count > 0 )) || { echo "PR #$pr_number has no reported checks." >&2; exit 1; }
+
+gh pr checks "$pr_number"
+
+repo_slug=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+owner=${repo_slug%%/*}
+name=${repo_slug#*/}
+unresolved=$(gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved isOutdated}}}}}' \
+  -F owner="$owner" \
+  -F name="$name" \
+  -F number="$pr_number" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false)] | length')
+[[ $unresolved == "0" ]] || {
+  echo "PR #$pr_number has $unresolved unresolved review thread(s)." >&2
+  exit 1
+}
+
+"$review_script" "$pr_number" "$base_ref"
+
+actual_sha=$(gh pr view "$pr_number" --json headRefOid --jq .headRefOid)
+[[ $actual_sha == "$expected_sha" ]] || {
+  echo "Head SHA changed during preflight: expected $expected_sha, found $actual_sha." >&2
+  exit 1
+}
+
+echo
+echo "Preflight passed for PR #$pr_number at $expected_sha."
+echo "No merge was performed. Use:"
+echo "gh pr merge $pr_number --squash --match-head-commit $expected_sha"

--- a/.agents/skills/check-mcp-json/scripts/review-pr.sh
+++ b/.agents/skills/check-mcp-json/scripts/review-pr.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <pr-number> [base-ref]" >&2
+  exit 2
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+pr_number=$1
+base_ref=${2:-origin/main}
+[[ $pr_number =~ ^[0-9]+$ ]] || usage
+
+for command in git gh node; do
+  command -v "$command" >/dev/null || {
+    echo "Required command not found: $command" >&2
+    exit 1
+  }
+done
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+trusted_sha=$(git -C "$repo_root" rev-parse HEAD)
+base_sha=$(git -C "$repo_root" rev-parse "$base_ref")
+
+if [[ $trusted_sha != "$base_sha" ]]; then
+  echo "Trusted checkout HEAD ($trusted_sha) does not match $base_ref ($base_sha)." >&2
+  echo "Refresh main before reviewing the pull request." >&2
+  exit 1
+fi
+
+if [[ -n $(git -C "$repo_root" status --porcelain) ]]; then
+  echo "Trusted checkout must be clean before reviewing a pull request." >&2
+  exit 1
+fi
+
+head_sha=$(gh pr view "$pr_number" --json headRefOid --jq .headRefOid)
+review_ref="refs/codex/review/$pr_number"
+temp_root=$(mktemp -d "${TMPDIR:-/tmp}/toolsdk-pr-${pr_number}.XXXXXX")
+review_dir="$temp_root/pr"
+
+cleanup() {
+  if [[ -d $review_dir ]]; then
+    git -C "$repo_root" worktree remove "$review_dir" >/dev/null 2>&1 || true
+  fi
+  rmdir "$temp_root" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git -C "$repo_root" fetch origin "pull/$pr_number/head:$review_ref" --force
+fetched_sha=$(git -C "$repo_root" rev-parse "$review_ref")
+if [[ $fetched_sha != "$head_sha" ]]; then
+  echo "PR head changed while preparing review: expected $head_sha, fetched $fetched_sha." >&2
+  echo "Rerun the review to bind validation to the latest head commit." >&2
+  exit 1
+fi
+
+echo "PR metadata:"
+gh pr view "$pr_number" --json number,title,state,isDraft,headRefOid,headRefName,headRepositoryOwner,maintainerCanModify,mergeable,mergeStateStatus,statusCheckRollup,url
+
+echo
+echo "Changed files:"
+gh pr diff "$pr_number" --name-only
+
+git -C "$repo_root" worktree add --detach "$review_dir" "$review_ref" >/dev/null
+
+echo
+echo "Trusted registry validation for PR #$pr_number at $head_sha:"
+node "$repo_root/scripts/validate-registry.mjs" \
+  --root "$review_dir" \
+  --base "$base_ref"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Registry Agent Instructions
 
 When reviewing or merging registry pull requests, follow `docs/PR_REVIEW.md`.
+Use `.agents/skills/check-mcp-json/SKILL.md` for the reusable review, repair, and exact-SHA merge
+workflow and its read-only helper scripts.
 
 - Use the validator from the trusted `main` branch to inspect pull request JSON. Do not execute
   scripts from a contributor branch.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 &nbsp;&nbsp;•&nbsp;&nbsp;
 <a href="#install-via-package-manager">📦 <b>Use as SDK</b></a>
 &nbsp;&nbsp;•&nbsp;&nbsp;
-<a href="#submit-new-mcp-servers">➕ <b>Add Server</b></a>
+<a href="./docs/CONTRIBUTING.md">➕ <b>Add Server</b></a>
 &nbsp;&nbsp;•&nbsp;&nbsp;
 <a href="https://www.youtube.com/watch?v=J_oaDtCoVVo" target="_blank">🎥 <b>Video Tutorial</b></a>
 
@@ -42,7 +42,7 @@
 - 🔍 I want to **find an MCP Server** → [Browse Directory](#mcp-servers)
 - 🔌 I want to **integrate MCP tools** into my AI app → [Integration Guide](https://toolsdk.ai/docs/tutorials/getting-started#-quick-start)
 - 🚀 I want to **deploy an MCP Gateway** → [Deployment Guide](#deploy-enterprise-gateway-recommended)
-- ➕ I want to **submit my MCP Server** → [Contribution Guide](#contribute-your-mcp-server)
+- ➕ I want to **submit my MCP Server** → [Contribution Guide](./docs/CONTRIBUTING.md)
 
 > [!IMPORTANT]
 > **Pro Tip**: If a server is marked as `validated: true`, you can use it instantly with **Vercel AI SDK**:
@@ -287,18 +287,6 @@ const searchTool = await searchMCP.getAISDKTool('tavily-search');
 - **Docker Image** - Full-featured Gateway & Registry
 - **NPM Package** - TypeScript/JavaScript SDK for data access
 - **Raw Data** - JSON endpoints for direct integration
-
----
-
-<a id="getting-started"></a>
-
-<a id="submit-new-mcp-servers"></a>
-
-## Contribute Your MCP Server
-
-Want to add your MCP server to the registry? Check out our [Contributing Guide](./docs/CONTRIBUTING.md) for the full submission process, JSON schema reference, and examples (including remote servers and OAuth 2.1).
-
-[![Watch the video](https://img.youtube.com/vi/J_oaDtCoVVo/hqdefault.jpg)](https://www.youtube.com/watch?v=J_oaDtCoVVo)
 
 ---
 
@@ -1496,4 +1484,3 @@ Miscellaneous tools and integrations that don’t fit into other categories.
 - [✅ ygg-torrent-mcp](https://github.com/philogicae/ygg-torrent-mcp): Provides secure access to YggTorrent through an unofficial API wrapper, enabling torrent searching with category filtering, detailed metadata retrieval, and magnet link generation with automatic passkey injection for authenticated downloads.  (5 tools) (python) 
 
 </details>
-

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,164 +1,235 @@
-# 🤝 Contributing to the ToolSDK MCP Registry
+# Contributing to the ToolSDK MCP Registry
 
-Thanks for your interest in contributing to ToolSDK MCP Registry! 🎉 Your help makes this registry of Model Context Protocol servers even more toolsdk.
+Thank you for contributing an MCP server, documentation improvement, or code change.
 
-## 🚀 Submit New MCP Servers
+This guide is the source of truth for registry submissions. The root README and generated indexes
+are outputs of the registry build and must not be edited to add a server. For an intentional README
+documentation change, edit `docs/_templates/README.tpl.md` and regenerate the README.
 
-Want to add a new MCP server to our registry? It's easy! Just follow these steps:
+## Submit an MCP Server
 
-1. **Fork this repo** 🍴 - Click the fork button at the top right of this page
-2. **Create a JSON file** 📄 - Add a new file named `your-mcp-server.json` in the [packages/uncategorized](../packages/uncategorized) folder. AI will automatically categorize it later.
-3. **Fill in the details** ✍️ - Use the format below.
-4. **Submit a pull request** 🚀 - We'll review it and merge it in!
+1. Fork the repository and create a focused branch.
+2. Add one JSON file under `packages/<category>/`.
+3. Validate the change against the latest `main`.
+4. Open a pull request that links the official package or server documentation.
 
-If you know which category your server fits into, feel free to put it in the appropriate folder instead of `uncategorized`.
+Prefer one MCP server per pull request. A PR may contain multiple closely related servers from the
+same publisher, but it must not include unrelated workspace, workflow, dependency, lockfile, README,
+or generated-index changes.
 
-### Minimal Example
+### File Location and Name
+
+- Choose a category defined in [`config/categories.mjs`](../config/categories.mjs). Use
+  [`packages/uncategorized`](../packages/uncategorized) when no category is a clear fit.
+- Place the file directly in that category directory; nested package directories are not supported.
+- Use a lowercase kebab-case filename, for example `packages/databases/example-mcp.json`.
+- Do not manually edit the root README or files under `indexes/`; they are generated. README
+  documentation changes belong in `docs/_templates/README.tpl.md`.
+
+### Source Requirements
+
+A registry entry must identify something users can actually connect to or run:
+
+- A local entry needs a public package or Docker image whose name and command can be verified.
+- A remote entry needs an official, public HTTPS Streamable HTTP endpoint.
+- The repository, package registry, license, environment variables, authentication, and description
+  must agree with the publisher's current documentation.
+- Do not submit an unpublished package, private repository, placeholder package name, unrelated npm
+  package, or a full application without a stable standalone MCP command or endpoint.
+
+Reviewers verify metadata from primary sources. They do not install or execute contributed MCP
+packages during review.
+
+## Local Package Example
 
 ```json
 {
   "type": "mcp-server",
-  "name": "Github",
-  "packageName": "@modelcontextprotocol/server-github",
-  "description": "MCP server for using the GitHub API",
-  "url": "https://github.com/modelcontextprotocol/servers/blob/main/src/github",
+  "name": "Example MCP Server",
+  "packageName": "example-mcp-server",
+  "description": "Provides example operations for MCP clients.",
+  "url": "https://github.com/example/example-mcp-server",
+  "readme": "https://github.com/example/example-mcp-server#readme",
   "runtime": "node",
   "license": "MIT",
   "env": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": {
-      "description": "Personal access token for GitHub API access",
-      "required": true
+    "EXAMPLE_API_KEY": {
+      "description": "API key for the Example service.",
+      "required": true,
+      "secret": true
     }
   }
 }
 ```
 
-> Every file that enters this repository will be validated by Zod. You can open [common-schema.ts](../src/shared/schemas/common-schema.ts) to see the definition of the Zod schema.
+For Node packages, normally omit `bin`. The gateway resolves the first `bin` entry, or `main`, from
+the installed package manifest. A configured `bin` is treated as a JavaScript entry-file path passed
+to Node; it is not an npm executable alias.
 
-### Validate Locally
-
-You can validate your JSON file before submitting a PR:
-
-```bash
-make validate packages/uncategorized/your-mcp-server.json
-```
-
-## 📋 JSON Schema Reference
-
-Here's the complete list of fields you can use in your MCP server configuration:
-
-| Field            | Type     | Required | Description                                                                                                |
-| ---------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `type`           | string   | Yes      | Must be `"mcp-server"`                                                                                     |
-| `runtime`        | string   | Yes      | Runtime environment: `"node"`, `"python"`, `"java"`, `"go"`, `"docker"`                                    |
-| `packageName`    | string   | Yes      | Name of the package (e.g. npm, PyPI, Maven package name, or Docker image)                                  |
-| `packageVersion` | string   | No       | Version of the package. If not provided, latest version will be used                                       |
-| `bin`            | string   | No       | Binary command to run the MCP server. If not provided, the package name will be used                       |
-| `binArgs`        | string[] | No       | Arguments to pass to the binary command. Defaults to an empty array                                        |
-| `key`            | string   | No       | Unique key for URL and slug. If not provided, the package name will be used                                |
-| `name`           | string   | No       | Custom display name. If not provided, the package name will be used                                        |
-| `description`    | string   | No       | Description of the MCP server                                                                              |
-| `readme`         | string   | No       | URL to the README file. If not provided, the package URL will be used                                      |
-| `url`            | string   | No       | GitHub repository URL                                                                                      |
-| `license`        | string   | No       | Open source license (e.g. MIT, AGPL, GPL)                                                                  |
-| `logo`           | string   | No       | URL to custom logo image. If the URL is GitHub and logo is not set, the GitHub avatar will be used         |
-| `author`         | string   | No       | Author name or ToolSDK.ai developer ID                                                                     |
-| `env`            | object   | No       | Environment variables required by the server. Use an empty object `{}` if none are needed                  |
-| `remotes`        | array    | No       | Remote server endpoints for hosted MCP servers (see [Remote MCP Servers](#-remote-mcp-servers) below)      |
-
-Each environment variable in the `env` object should have:
-
-- `description` (string): A brief description of what the variable is used for
-- `required` (boolean): Whether the variable is required
-- `default` (string, optional): A non-secret default value
-- `secret` (boolean, optional): Whether clients should treat the value as sensitive. Secret values
-  cannot define defaults.
-
-## 🌐 Remote MCP Servers
-
-If your MCP server supports remote hosting via Streamable HTTP transport, you can add a `remotes` array to enable direct connection without local installation:
+For Docker entries, use the published image as `packageName`, set `runtime` to `docker`, and put the
+complete Docker CLI argument list in `binArgs`:
 
 ```json
 {
   "type": "mcp-server",
-  "name": "Remote GitHub MCP Server",
-  "packageName": "@toolsdk-remote/github-mcp",
-  "description": "A GitHub automation tool with remote hosting support",
+  "name": "Example Docker MCP",
+  "packageName": "ghcr.io/example/example-mcp",
+  "description": "Runs the Example MCP server from its published container image.",
+  "url": "https://github.com/example/example-mcp",
+  "runtime": "docker",
+  "license": "MIT",
+  "binArgs": ["run", "--rm", "-i", "ghcr.io/example/example-mcp:latest"],
+  "env": {}
+}
+```
+
+The image and referenced tag must exist.
+
+## Remote MCP Servers
+
+Remote servers use a registry placeholder beginning with `@toolsdk-remote/` and a non-empty
+`remotes` array:
+
+```json
+{
+  "type": "mcp-server",
+  "name": "Example Remote MCP",
+  "packageName": "@toolsdk-remote/example-mcp",
+  "description": "Connects to the hosted Example MCP endpoint.",
+  "url": "https://github.com/example/example-mcp",
   "runtime": "node",
+  "license": "MIT",
   "env": {},
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://your-server.com/mcp"
+      "url": "https://example.com/mcp"
     }
   ]
 }
 ```
 
-### Remote with OAuth 2.1 Authentication
+Remote rules:
 
-For MCP servers that require OAuth 2.1 authentication, add the `auth` configuration:
+- `packageName` must start with `@toolsdk-remote/`.
+- A package beginning with `@toolsdk-remote/` must define at least one remote endpoint.
+- Do not define `key`; the remote `packageName` is its registry and gateway identity.
+- Endpoints must use HTTPS and cannot target localhost or a private network.
+- `runtime: "remote"` is not valid. Use the implementation runtime when known. For a hosted-only
+  server without local runtime metadata, use `node`; the remote transport is selected first.
+
+### OAuth 2.1
+
+The registry can describe OAuth2 authentication:
 
 ```json
 {
   "type": "mcp-server",
-  "name": "OAuth GitHub MCP Server",
-  "packageName": "@toolsdk-remote/github-mcp",
-  "description": "GitHub MCP with OAuth authentication",
+  "name": "Example OAuth MCP",
+  "packageName": "@toolsdk-remote/example-oauth-mcp",
+  "description": "Connects to the hosted Example MCP endpoint using OAuth.",
   "runtime": "node",
   "env": {},
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://your-server.com/mcp",
+      "url": "https://example.com/mcp",
       "auth": {
         "type": "oauth2",
-        "scopes": ["repo", "user"]
+        "scopes": ["read", "write"]
       }
     }
   ]
 }
 ```
 
-### Remote Configuration Fields
+OAuth2 is currently the only supported remote `auth.type`. Bearer/API-key header metadata and
+credentials embedded dynamically in remote URLs are not supported. Do not model Bearer auth as
+OAuth2 or add an environment variable expecting the remote transport to inject it. A server with a
+useful unauthenticated subset may be listed without `auth` when the description clearly states the
+limitation. `auth.scopes` is optional; when present, it must be an array of strings.
 
-| Field         | Type     | Required | Description                                              |
-| ------------- | -------- | -------- | -------------------------------------------------------- |
-| `type`        | string   | Yes      | Transport type. Currently only `"streamable-http"`       |
-| `url`         | string   | Yes      | Remote server endpoint URL (must be a valid URL)         |
-| `auth`        | object   | No       | Authentication configuration                             |
-| `auth.type`   | string   | Yes*     | Authentication type. Currently only `"oauth2"`           |
-| `auth.scopes` | string[] | No       | OAuth scopes to request                                  |
+## Configuration Fields
 
-> *Required when `auth` object is provided
+Package JSON is strict. Unknown fields are rejected.
 
-Every configuration with a non-empty `remotes` array must use a `packageName` beginning with
-`@toolsdk-remote/`. Remote endpoints must use HTTPS and cannot point to localhost or a private
-network. Remote configurations cannot define a custom `key`; their `packageName` is also their
-registry and gateway identity.
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | Yes | Must be `"mcp-server"`. |
+| `runtime` | string | Yes | One of `node`, `python`, `java`, `go`, or `docker`. |
+| `packageName` | string | Yes | Published package/image identity, or an `@toolsdk-remote/` placeholder. |
+| `packageVersion` | string | No | Package version; latest is used when omitted. |
+| `bin` | string | No | Node entry-file path. Normally omit and use the package manifest. |
+| `binArgs` | string[] | No | Arguments passed to the runtime command. |
+| `remotes` | array | No | Hosted Streamable HTTP endpoints. |
+| `key` | string | No | Custom local registry identity. Forbidden for remote entries. |
+| `name` | string | No | Display name. |
+| `description` | string | No | Accurate, current summary of the server's capabilities. |
+| `readme` | string | No | Official README or documentation URL. |
+| `url` | string | No | Official package or source repository URL. |
+| `license` | string | No | License reported by the official source. |
+| `logo` | string | No | Custom logo URL. |
+| `author` | string | No | Publisher or ToolSDK developer identifier. |
+| `env` | object | No | Environment-variable metadata; use `{}` when none are needed. |
 
-New package keys must be unique. The registry uses `key` when provided and otherwise falls back to
-`packageName`; a new file cannot reuse an identity already present in the registry.
+Each environment variable requires:
 
-## 💻 Code Contributions
+- `description`: what the value is used for.
+- `required`: whether the server can start or provide its advertised capability without it.
+- `secret` (optional): set to `true` for tokens, passwords, private keys, and similar credentials.
+- `default` (optional): a non-secret default value. Secret variables cannot define defaults.
 
-We warmly welcome contributions to both our **code** and **documentation**.
-Whether you're fixing a small bug, improving performance, or adding an exciting new feature, your efforts are valued. 💪
+## Registry Identity and Duplicates
 
-### How You Can Contribute
+The effective identity is `key` when a non-empty custom key is present; otherwise it is
+`packageName`.
 
-- 🛠 **Fix bugs** — squash those pesky issues
-- ✨ **Add new features** — bring your ideas to life
-- 📚 **Improve documentation** — make it clearer and more complete
-- ⚡ **Optimize code** — enhance performance and readability
+- New entries must not reuse an identity already present on the latest `main`.
+- A new file cannot replace an existing identity, even when the old file would be deleted in the
+  same PR.
+- Historical duplicate identities are tolerated only while unchanged; a PR cannot introduce a new
+  collision.
+- Use a custom `key` only when a local package needs a stable identity distinct from its package
+  name. Never use it to take over an existing entry.
 
-Don't worry about perfection — **just submit your work**!
-Our team will review, provide feedback, and help polish it before merging. 🙌
+## Validate Before Opening a PR
 
-> 💡 Tip: Even small changes matter — every pull request counts!
+The registry validator uses Node.js built-ins and does not require installing repository
+dependencies.
 
-## 🎉 Thanks for Making MCP ToolSDK!
+```bash
+git fetch origin main
+node scripts/validate-registry.mjs --base origin/main
+```
 
-Your contributions help build a better ecosystem for everyone working with Model Context Protocol servers. Every addition matters! ❤️
+This validates the package JSON changed by your branch and checks identities against the current
+base. To validate every registry entry in the working tree:
 
-For detailed technical information, check out our [Development Guide](./DEVELOPMENT.md) and [Guide](./guide.md).
+```bash
+node scripts/validate-registry.mjs --all
+```
+
+Do not use `make build` as a submission validator. It installs and executes registry packages and
+also regenerates repository outputs.
+
+## Pull Request Checklist
+
+- [ ] The PR contains only the intended package JSON file or closely related package files.
+- [ ] The filename is lowercase kebab-case and the category exists.
+- [ ] Package/image names, tags, commands, endpoints, auth, environment variables, and license were
+      checked against official sources.
+- [ ] The effective registry identity is new.
+- [ ] Remote entries follow the `@toolsdk-remote/` and `remotes` rules.
+- [ ] Secrets are marked and have no defaults.
+- [ ] `node scripts/validate-registry.mjs --base origin/main` passes.
+- [ ] The PR description links the official package, repository, or endpoint documentation.
+
+CI passing is required but is not the final review. Maintainers also inspect the diff and verify the
+source metadata. When the fork allows maintainer edits, an authorized maintainer may push a small
+metadata correction to the contributor branch; any new commit is reviewed again before merge.
+
+## Code and Documentation Contributions
+
+Keep code changes separate from registry-entry submissions when possible. Describe the behavior,
+tests, and migration impact in the PR. See the [Development Guide](./DEVELOPMENT.md) and
+[Registry PR Review](./PR_REVIEW.md) for repository-specific engineering and review rules.

--- a/docs/_templates/README.tpl.md
+++ b/docs/_templates/README.tpl.md
@@ -25,7 +25,7 @@
 &nbsp;&nbsp;•&nbsp;&nbsp;
 <a href="#install-via-package-manager">📦 <b>Use as SDK</b></a>
 &nbsp;&nbsp;•&nbsp;&nbsp;
-<a href="#submit-new-mcp-servers">➕ <b>Add Server</b></a>
+<a href="./docs/CONTRIBUTING.md">➕ <b>Add Server</b></a>
 &nbsp;&nbsp;•&nbsp;&nbsp;
 <a href="https://www.youtube.com/watch?v=J_oaDtCoVVo" target="_blank">🎥 <b>Video Tutorial</b></a>
 
@@ -42,7 +42,7 @@
 - 🔍 I want to **find an MCP Server** → [Browse Directory](#mcp-servers)
 - 🔌 I want to **integrate MCP tools** into my AI app → [Integration Guide](https://toolsdk.ai/docs/tutorials/getting-started#-quick-start)
 - 🚀 I want to **deploy an MCP Gateway** → [Deployment Guide](#deploy-enterprise-gateway-recommended)
-- ➕ I want to **submit my MCP Server** → [Contribution Guide](#contribute-your-mcp-server)
+- ➕ I want to **submit my MCP Server** → [Contribution Guide](./docs/CONTRIBUTING.md)
 
 > [!IMPORTANT]
 > **Pro Tip**: If a server is marked as `validated: true`, you can use it instantly with **Vercel AI SDK**:
@@ -287,18 +287,6 @@ const searchTool = await searchMCP.getAISDKTool('tavily-search');
 - **Docker Image** - Full-featured Gateway & Registry
 - **NPM Package** - TypeScript/JavaScript SDK for data access
 - **Raw Data** - JSON endpoints for direct integration
-
----
-
-<a id="getting-started"></a>
-
-<a id="submit-new-mcp-servers"></a>
-
-## Contribute Your MCP Server
-
-Want to add your MCP server to the registry? Check out our [Contributing Guide](./docs/CONTRIBUTING.md) for the full submission process, JSON schema reference, and examples (including remote servers and OAuth 2.1).
-
-[![Watch the video](https://img.youtube.com/vi/J_oaDtCoVVo/hqdefault.jpg)](https://www.youtube.com/watch?v=J_oaDtCoVVo)
 
 ---
 


### PR DESCRIPTION
## Summary

- add a reusable `check-mcp-json` skill for reviewing, repairing, and exact-SHA merging registry PRs
- add read-only review and merge-preflight helper scripts with trusted-base and head-SHA checks
- replace the contribution guide with current package, remote, identity, and validation rules
- update the README template and generated README to link directly to the contribution guide
- document supported `env.*.secret` and `remotes[].auth.scopes` fields

## Safety

- never installs or executes contributed MCP packages
- requires explicit authorization before editing, commenting, closing, or merging community PRs
- validates from trusted `main` and binds merge approval to an exact head SHA
- uses squash merge with `--match-head-commit` and never bypasses checks

## Validation

- `python3 .../skill-creator/scripts/quick_validate.py .agents/skills/check-mcp-json`
- `bash -n .agents/skills/check-mcp-json/scripts/review-pr.sh .agents/skills/check-mcp-json/scripts/preflight-merge.sh`
- `node --test scripts/lib/registry-validator.node-test.mjs scripts/validate-registry.node-test.mjs` (12 passed)
- explicit validator examples for `secret` and `auth.scopes`
- `node scripts/validate-registry.mjs --all` (4907 files, 0 errors, 0 warnings)
- trusted README generator completed successfully; unrelated catalog refresh output was excluded

No dependencies were installed and no MCP package was executed.